### PR TITLE
Added Support for Multitenant, push of parameters and bug fix api connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Run the PowerShell command `Get-LogicAppTemplate`.  You can pipe the output as n
 
 `armclient token 80d4fe69-xxxx-4dd2-a938-9250f1c8ab03 | Get-LogicAppTemplate -LogicApp MyApp -ResourceGroup Integrate2016 -SubscriptionId 80d4fe69-xxxx-4dd2-a938-9250f1c8ab03 -Verbose | Out-File C:\template.json`
 
+Example when user is connected to multitenants
+Get-LogicAppTemplate -LogicApp MyApp -ResourceGroup Integrate2016 -SubscriptionId 80d4fe69-xxxx-4dd2-a938-9250f1c8ab03 -TenantName contoso.onmicrosoft.com
+
 ### Specifications
 
 | Parameter | Description | Required |
@@ -21,5 +24,6 @@ Run the PowerShell command `Get-LogicAppTemplate`.  You can pipe the output as n
 | LogicApp | The name of the Logic App | true |
 | ResourceGroup | The name of the Resource Group | true |
 | SubscriptionId | The subscription Id for the resource | true |
+| TenantName | Name of the Tenant i.e. contoso.onmicrosoft.com | false |
 | Token | An AAD Token to access the resources - should not include `Bearer`, only the token | false |
 | ClaimsDump | A dump of claims piped in from `armclient` - should not be manually set | false |


### PR DESCRIPTION
Added support for multitenant, meaning that users that have multiple tenants can target a a specific tenant when authenticating. Solves problem of "Not Authenticated" when the subscription is not placed in the default tenant.

Pushing Logic App parameters to Template parameters for easier parameterization (filter on parameters not starting with $ i.e. connections)

Fixed a bug with API Connections where the current subscription was hard coded in the template, now properly using the subscription().id so that the connection is linked via the current subscription.