### PR TITLE
Extraction updates and added parameter generation function

### DIFF
--- a/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
+++ b/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
@@ -50,13 +50,16 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TemplateGeneratorTests.cs" />
+    <Compile Include="ParamGeneratorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LogicAppTemplate\LogicAppTemplate.csproj">
@@ -72,6 +75,8 @@
     <EmbeddedResource Include="TestFiles\APIMMultipleSame.json" />
     <EmbeddedResource Include="TestFiles\APIMMultipleDiffrent.json" />
     <EmbeddedResource Include="TestFiles\complex-logicapp-if.json" />
+    <EmbeddedResource Include="TestFiles\Switch.json" />
+    <EmbeddedResource Include="TestFiles\paramGeneratorLogicAppTemplate.json" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
+++ b/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
@@ -71,6 +71,7 @@
     <EmbeddedResource Include="TestFiles\integrationaccount.json" />
     <EmbeddedResource Include="TestFiles\APIMMultipleSame.json" />
     <EmbeddedResource Include="TestFiles\APIMMultipleDiffrent.json" />
+    <EmbeddedResource Include="TestFiles\complex-logicapp-if.json" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
+++ b/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
@@ -66,6 +66,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <EmbeddedResource Include="TestFiles\WorkflowTest.json" />
+    <EmbeddedResource Include="TestFiles\APIM.json" />
+    <EmbeddedResource Include="TestFiles\integrationaccount.json" />
+    <EmbeddedResource Include="TestFiles\APIMMultipleSame.json" />
+    <EmbeddedResource Include="TestFiles\APIMMultipleDiffrent.json" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/LogicAppTemplate.Test/ParamGeneratorTests.cs
+++ b/LogicAppTemplate.Test/ParamGeneratorTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using Newtonsoft.Json.Linq;
+
+namespace LogicAppTemplate.Test
+{
+    [TestClass]
+    public class ParamGeneratorTests
+    {
+        [TestMethod]
+        public void CreateParamGeneratorClass()
+        {
+            new ParamGenerator();
+        }
+
+        [TestMethod]
+        public void GenerateParameterFileFromTemplate()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.paramGeneratorLogicAppTemplate.json");
+            var generator = new ParamGenerator();
+
+            var defintion = generator.CreateParameterFileFromTemplate(JObject.Parse(content));
+
+            //check parameters
+            Assert.IsNull(defintion["parameters"]["INT0014-NewHires-ResourceGroup"]);
+            Assert.AreEqual("[resourceGroup().location]", defintion["parameters"]["logicAppLocation"]["value"]);
+            Assert.AreEqual("INT0014-NewHires-Trigger", defintion["parameters"]["logicAppName"]["value"]);
+        }
+
+
+             //var resourceName = "LogicAppTemplate.Templates.starterTemplate.json";
+        private static string GetEmbededFileContent(string resourceName)
+        {
+            var assembly = System.Reflection.Assembly.GetExecutingAssembly();
+
+
+            using (Stream stream = assembly.GetManifestResourceStream(resourceName))
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                return reader.ReadToEnd();
+            }
+
+        }
+    }
+}

--- a/LogicAppTemplate.Test/TemplateGeneratorTests.cs
+++ b/LogicAppTemplate.Test/TemplateGeneratorTests.cs
@@ -140,6 +140,22 @@ namespace LogicAppTemplate.Tests
             Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimLocation'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment3"]["inputs"]["api"]["id"]);
             Assert.AreEqual("[parameters('apimSubscriptionKey')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment3"]["inputs"]["subscriptionKey"]);
         }
+        [TestMethod()]
+        public void TestIFStatements()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.complex-logicapp-if.json");
+
+            var generator = new TemplateGenerator();
+
+            var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
+
+            //check parameters
+            //Assert.AreEqual("resourcegroupname", defintion["parameters"]["INT0014-NewHires-ResourceGroup"]["defaultValue"]);
+
+            //check Upload Attachment
+            //Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('INT0014-NewHires-ResourceGroup'),'/providers/Microsoft.Logic/workflows/INT0014-NewHires')]", defintion["resources"][0]["properties"]["definition"]["actions"]["INT0014-NewHires"]["inputs"]["host"]["workflow"]["id"]);
+        }
+
 
         //var resourceName = "LogicAppTemplate.Templates.starterTemplate.json";
         private static string GetEmbededFileContent(string resourceName)

--- a/LogicAppTemplate.Test/TemplateGeneratorTests.cs
+++ b/LogicAppTemplate.Test/TemplateGeneratorTests.cs
@@ -45,10 +45,12 @@ namespace LogicAppTemplate.Tests
             var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
 
             //check parameters
-            Assert.AreEqual("resourcegroupname", defintion["parameters"]["INT0014-NewHires-ResourceGroup"]["defaultValue"]);            
+            Assert.IsNull(defintion["parameters"]["INT0014-NewHires-ResourceGroup"]);
+            Assert.AreEqual("[resourceGroup().location]", defintion["parameters"]["logicAppLocation"]["defaultValue"]);
+            Assert.AreEqual("INT0014-NewHires-Trigger", defintion["parameters"]["logicAppName"]["defaultValue"]);
 
             //check Upload Attachment
-            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('INT0014-NewHires-ResourceGroup'),'/providers/Microsoft.Logic/workflows/INT0014-NewHires')]", defintion["resources"][0]["properties"]["definition"]["actions"]["INT0014-NewHires"]["inputs"]["host"]["workflow"]["id"]);
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', resourceGroup().id,'/providers/Microsoft.Logic/workflows/INT0014-NewHires')]", defintion["resources"][0]["properties"]["definition"]["actions"]["INT0014-NewHires"]["inputs"]["host"]["workflow"]["id"]);
         }
 
         [TestMethod()]
@@ -150,10 +152,10 @@ namespace LogicAppTemplate.Tests
             var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
 
             //check parameters
-            //Assert.AreEqual("resourcegroupname", defintion["parameters"]["INT0014-NewHires-ResourceGroup"]["defaultValue"]);
 
-            //check Upload Attachment
-            //Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('INT0014-NewHires-ResourceGroup'),'/providers/Microsoft.Logic/workflows/INT0014-NewHires')]", defintion["resources"][0]["properties"]["definition"]["actions"]["INT0014-NewHires"]["inputs"]["host"]["workflow"]["id"]);
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', resourceGroup().id,'/providers/Microsoft.Logic/workflows/INT002_Create_Actioncode')]", defintion["resources"][0]["properties"]["definition"]["actions"]["Choose_external_procedure"]["actions"]["actions"]["INT002_Create_Actioncode"]["inputs"]["host"]["workflow"]["id"]);
+            //check nested nested action
+
         }
 
 

--- a/LogicAppTemplate.Test/TemplateGeneratorTests.cs
+++ b/LogicAppTemplate.Test/TemplateGeneratorTests.cs
@@ -7,6 +7,9 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using System.Diagnostics;
+using System.IO;
+using Newtonsoft.Json;
+using LogicAppTemplate.Models;
 
 namespace LogicAppTemplate.Tests
 {
@@ -29,6 +32,127 @@ namespace LogicAppTemplate.Tests
             Console.WriteLine(result.ToString(Newtonsoft.Json.Formatting.Indented));
             Assert.IsInstanceOfType(result, typeof(JObject));
             Assert.IsNotNull(result);
+        }
+
+
+        [TestMethod()]
+        public void TestWorkflow()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.WorkflowTest.json");
+
+            var generator = new TemplateGenerator();
+
+            var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
+
+            //check parameters
+            Assert.AreEqual("resourcegroupname", defintion["parameters"]["INT0014-NewHires-ResourceGroup"]["defaultValue"]);            
+
+            //check Upload Attachment
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('INT0014-NewHires-ResourceGroup'),'/providers/Microsoft.Logic/workflows/INT0014-NewHires')]", defintion["resources"][0]["properties"]["definition"]["actions"]["INT0014-NewHires"]["inputs"]["host"]["workflow"]["id"]);
+        }
+
+        [TestMethod()]
+        public void TestAPIM()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.APIM.json");
+
+            var generator = new TemplateGenerator();
+
+            var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
+            //check parameters
+            Assert.AreEqual("Api-Default-West-Europe", defintion["parameters"]["apimLocation"]["defaultValue"]);
+            Assert.AreEqual("apiminstancename", defintion["parameters"]["apimInstanceName"]["defaultValue"]);
+            Assert.AreEqual("58985740990a990dd41e5392", defintion["parameters"]["apimApiId"]["defaultValue"]);
+            Assert.AreEqual("8266eb865e6c440eb007067773e6890b", defintion["parameters"]["apimSubscriptionKey"]["defaultValue"]);
+
+            //check Upload Attachment
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimLocation'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["api"]["id"]);
+            Assert.AreEqual("[parameters('apimSubscriptionKey')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["subscriptionKey"]);
+        }
+
+
+        [TestMethod()]
+        public void TestAPIMMultipleSame()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.APIMMultipleSame.json");
+
+            var generator = new TemplateGenerator();
+
+            var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
+
+            //check parameters
+            Assert.AreEqual("Api-Default-West-Europe", defintion["parameters"]["apimLocation"]["defaultValue"]);
+            Assert.AreEqual("apiminstancename", defintion["parameters"]["apimInstanceName"]["defaultValue"]);
+            Assert.AreEqual("58985740990a990dd41e5392", defintion["parameters"]["apimApiId"]["defaultValue"]);
+            Assert.AreEqual("8266eb865e6c440eb007067773e6890b", defintion["parameters"]["apimSubscriptionKey"]["defaultValue"]);
+
+            //check parameters 2 is null
+            Assert.IsNull(defintion["parameters"]["apimLocation2"]);
+            Assert.IsNull(defintion["parameters"]["apimInstanceName2"]);
+            Assert.IsNull(defintion["parameters"]["apimApiId2"]);
+            Assert.IsNull(defintion["parameters"]["apimSubscriptionKey2"]);
+
+            //check Upload Attachment
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimLocation'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["api"]["id"]);
+            Assert.AreEqual("[parameters('apimSubscriptionKey')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["subscriptionKey"]);
+            //check upload Attachment 2
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimLocation'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment2"]["inputs"]["api"]["id"]);
+            Assert.AreEqual("[parameters('apimSubscriptionKey')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment2"]["inputs"]["subscriptionKey"]);
+        }
+
+
+        [TestMethod()]
+        public void TestAPIMMultipleDiffrent()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.APIMMultipleDiffrent.json");
+
+            var generator = new TemplateGenerator();
+
+            var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
+
+            //check parameters
+            Assert.AreEqual("Api-Default-West-Europe", defintion["parameters"]["apimLocation"]["defaultValue"]);
+            Assert.AreEqual("apiminstancename", defintion["parameters"]["apimInstanceName"]["defaultValue"]);
+            Assert.AreEqual("58985740990a990dd41e5392", defintion["parameters"]["apimApiId"]["defaultValue"]);
+            Assert.AreEqual("8266eb865e6c440eb007067773e6890b", defintion["parameters"]["apimSubscriptionKey"]["defaultValue"]);
+
+            //check Upload Attachment
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimLocation'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["api"]["id"]);
+            Assert.AreEqual("[parameters('apimSubscriptionKey')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["subscriptionKey"]);
+
+            //check parameters 2
+            Assert.AreEqual("APIintegration", defintion["parameters"]["apimLocation2"]["defaultValue"]);
+            Assert.AreEqual("otherapiminstancename", defintion["parameters"]["apimInstanceName2"]["defaultValue"]);
+            Assert.AreEqual("78985740990a990dd41e5392", defintion["parameters"]["apimApiId2"]["defaultValue"]);
+            Assert.AreEqual("F266eb865e6c440eb007067773e6890b", defintion["parameters"]["apimSubscriptionKey2"]["defaultValue"]);
+            //check upload Attachment 2
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimLocation2'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName2'),'/apis/', parameters('apimApiId2'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment2"]["inputs"]["api"]["id"]);
+            Assert.AreEqual("[parameters('apimSubscriptionKey2')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment2"]["inputs"]["subscriptionKey"]);
+
+
+            //check parameters 3 is null
+            Assert.IsNull(defintion["parameters"]["apimLocation3"]);
+            Assert.IsNull(defintion["parameters"]["apimInstanceName3"]);
+            Assert.IsNull(defintion["parameters"]["apimApiId3"]);
+            Assert.IsNull(defintion["parameters"]["apimSubscriptionKey3"]);
+            
+            //check upload Attachment3 should be same as 1
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimLocation'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment3"]["inputs"]["api"]["id"]);
+            Assert.AreEqual("[parameters('apimSubscriptionKey')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment3"]["inputs"]["subscriptionKey"]);
+        }
+
+        //var resourceName = "LogicAppTemplate.Templates.starterTemplate.json";
+        private static string GetEmbededFileContent(string resourceName)
+        {
+            var assembly = System.Reflection.Assembly.GetExecutingAssembly();
+            
+
+            using (Stream stream = assembly.GetManifestResourceStream(resourceName))
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                return reader.ReadToEnd();
+            }
+
         }
     }
 }

--- a/LogicAppTemplate.Test/TemplateGeneratorTests.cs
+++ b/LogicAppTemplate.Test/TemplateGeneratorTests.cs
@@ -50,7 +50,7 @@ namespace LogicAppTemplate.Tests
             Assert.AreEqual("INT0014-NewHires-Trigger", defintion["parameters"]["logicAppName"]["defaultValue"]);
 
             //check Upload Attachment
-            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', resourceGroup().id,'/providers/Microsoft.Logic/workflows/INT0014-NewHires')]", defintion["resources"][0]["properties"]["definition"]["actions"]["INT0014-NewHires"]["inputs"]["host"]["workflow"]["id"]);
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', resourceGroup().name,'/providers/Microsoft.Logic/workflows/INT0014-NewHires')]", defintion["resources"][0]["properties"]["definition"]["actions"]["INT0014-NewHires"]["inputs"]["host"]["workflow"]["id"]);
         }
 
         [TestMethod()]
@@ -62,13 +62,13 @@ namespace LogicAppTemplate.Tests
 
             var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
             //check parameters
-            Assert.AreEqual("Api-Default-West-Europe", defintion["parameters"]["apimLocation"]["defaultValue"]);
+            Assert.AreEqual("Api-Default-West-Europe", defintion["parameters"]["apimResourceGroup"]["defaultValue"]);
             Assert.AreEqual("apiminstancename", defintion["parameters"]["apimInstanceName"]["defaultValue"]);
             Assert.AreEqual("58985740990a990dd41e5392", defintion["parameters"]["apimApiId"]["defaultValue"]);
             Assert.AreEqual("8266eb865e6c440eb007067773e6890b", defintion["parameters"]["apimSubscriptionKey"]["defaultValue"]);
 
             //check Upload Attachment
-            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimLocation'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["api"]["id"]);
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimResourceGroup'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["api"]["id"]);
             Assert.AreEqual("[parameters('apimSubscriptionKey')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["subscriptionKey"]);
         }
 
@@ -83,22 +83,22 @@ namespace LogicAppTemplate.Tests
             var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
 
             //check parameters
-            Assert.AreEqual("Api-Default-West-Europe", defintion["parameters"]["apimLocation"]["defaultValue"]);
+            Assert.AreEqual("Api-Default-West-Europe", defintion["parameters"]["apimResourceGroup"]["defaultValue"]);
             Assert.AreEqual("apiminstancename", defintion["parameters"]["apimInstanceName"]["defaultValue"]);
             Assert.AreEqual("58985740990a990dd41e5392", defintion["parameters"]["apimApiId"]["defaultValue"]);
             Assert.AreEqual("8266eb865e6c440eb007067773e6890b", defintion["parameters"]["apimSubscriptionKey"]["defaultValue"]);
 
             //check parameters 2 is null
-            Assert.IsNull(defintion["parameters"]["apimLocation2"]);
+            Assert.IsNull(defintion["parameters"]["apimResourceGroup2"]);
             Assert.IsNull(defintion["parameters"]["apimInstanceName2"]);
             Assert.IsNull(defintion["parameters"]["apimApiId2"]);
             Assert.IsNull(defintion["parameters"]["apimSubscriptionKey2"]);
 
             //check Upload Attachment
-            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimLocation'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["api"]["id"]);
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimResourceGroup'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["api"]["id"]);
             Assert.AreEqual("[parameters('apimSubscriptionKey')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["subscriptionKey"]);
             //check upload Attachment 2
-            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimLocation'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment2"]["inputs"]["api"]["id"]);
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimResourceGroup'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment2"]["inputs"]["api"]["id"]);
             Assert.AreEqual("[parameters('apimSubscriptionKey')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment2"]["inputs"]["subscriptionKey"]);
         }
 
@@ -113,33 +113,33 @@ namespace LogicAppTemplate.Tests
             var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
 
             //check parameters
-            Assert.AreEqual("Api-Default-West-Europe", defintion["parameters"]["apimLocation"]["defaultValue"]);
+            Assert.AreEqual("Api-Default-West-Europe", defintion["parameters"]["apimResourceGroup"]["defaultValue"]);
             Assert.AreEqual("apiminstancename", defintion["parameters"]["apimInstanceName"]["defaultValue"]);
             Assert.AreEqual("58985740990a990dd41e5392", defintion["parameters"]["apimApiId"]["defaultValue"]);
             Assert.AreEqual("8266eb865e6c440eb007067773e6890b", defintion["parameters"]["apimSubscriptionKey"]["defaultValue"]);
 
             //check Upload Attachment
-            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimLocation'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["api"]["id"]);
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimResourceGroup'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["api"]["id"]);
             Assert.AreEqual("[parameters('apimSubscriptionKey')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment"]["inputs"]["subscriptionKey"]);
 
             //check parameters 2
-            Assert.AreEqual("APIintegration", defintion["parameters"]["apimLocation2"]["defaultValue"]);
+            Assert.AreEqual("APIintegration", defintion["parameters"]["apimResourceGroup2"]["defaultValue"]);
             Assert.AreEqual("otherapiminstancename", defintion["parameters"]["apimInstanceName2"]["defaultValue"]);
             Assert.AreEqual("78985740990a990dd41e5392", defintion["parameters"]["apimApiId2"]["defaultValue"]);
             Assert.AreEqual("F266eb865e6c440eb007067773e6890b", defintion["parameters"]["apimSubscriptionKey2"]["defaultValue"]);
             //check upload Attachment 2
-            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimLocation2'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName2'),'/apis/', parameters('apimApiId2'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment2"]["inputs"]["api"]["id"]);
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimResourceGroup2'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName2'),'/apis/', parameters('apimApiId2'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment2"]["inputs"]["api"]["id"]);
             Assert.AreEqual("[parameters('apimSubscriptionKey2')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment2"]["inputs"]["subscriptionKey"]);
 
 
             //check parameters 3 is null
-            Assert.IsNull(defintion["parameters"]["apimLocation3"]);
+            Assert.IsNull(defintion["parameters"]["apimResourceGroup3"]);
             Assert.IsNull(defintion["parameters"]["apimInstanceName3"]);
             Assert.IsNull(defintion["parameters"]["apimApiId3"]);
             Assert.IsNull(defintion["parameters"]["apimSubscriptionKey3"]);
             
             //check upload Attachment3 should be same as 1
-            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimLocation'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment3"]["inputs"]["api"]["id"]);
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimResourceGroup'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment3"]["inputs"]["api"]["id"]);
             Assert.AreEqual("[parameters('apimSubscriptionKey')]", defintion["resources"][0]["properties"]["definition"]["actions"]["UploadAttachment3"]["inputs"]["subscriptionKey"]);
         }
         [TestMethod()]
@@ -153,7 +153,24 @@ namespace LogicAppTemplate.Tests
 
             //check parameters
 
-            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', resourceGroup().id,'/providers/Microsoft.Logic/workflows/INT002_Create_Actioncode')]", defintion["resources"][0]["properties"]["definition"]["actions"]["Choose_external_procedure"]["actions"]["actions"]["INT002_Create_Actioncode"]["inputs"]["host"]["workflow"]["id"]);
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', resourceGroup().name,'/providers/Microsoft.Logic/workflows/INT002_Create_Actioncode')]", defintion["resources"][0]["properties"]["definition"]["actions"]["Choose_external_procedure"]["actions"]["INT002_Create_Actioncode"]["inputs"]["host"]["workflow"]["id"]);
+            //check nested nested action
+
+        }
+
+        [TestMethod()]
+        public void TestSwitchStatements()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.Switch.json");
+
+            var generator = new TemplateGenerator();
+
+            var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
+
+            //check parameters
+
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimResourceGroup'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["Condition"]["actions"]["Switch"]["default"]["actions"]["INT002_Create_Actioncode_2"]["inputs"]["api"]["id"]);
+            Assert.AreEqual("[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', parameters('apimResourceGroup'),'/providers/Microsoft.ApiManagement/service/', parameters('apimInstanceName'),'/apis/', parameters('apimApiId'),'')]", defintion["resources"][0]["properties"]["definition"]["actions"]["Condition"]["actions"]["Switch"]["cases"]["Case"]["actions"]["For_each"]["actions"]["INT002_Create_Actioncode"]["inputs"]["api"]["id"]);
             //check nested nested action
 
         }

--- a/LogicAppTemplate.Test/TestFiles/APIM.json
+++ b/LogicAppTemplate.Test/TestFiles/APIM.json
@@ -1,0 +1,86 @@
+﻿{
+  "properties": {
+    "provisioningState": "Succeeded",
+    "createdTime": "2017-02-09T09:10:49.3907663Z",
+    "changedTime": "2017-02-09T11:37:16.6548587Z",
+    "state": "Enabled",
+    "version": "08587149666489087757",
+    "accessEndpoint": "https://prod-24.westeurope.logic.azure.com:443/workflows/x",
+    "definition": {
+      "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {},
+      "triggers": {
+        "request": {
+          "type": "Request",
+          "kind": "Http",
+          "inputs": {
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "properties": {
+                "data": { "type": "string" },
+                "extension": { "type": "string" },
+                "filename": { "type": "string" },
+                "orderNumber": { "type": "string" }
+              },
+              "required": [ "orderNumber", "filename", "extension", "data" ],
+              "type": "object"
+            }
+          }
+        }
+      },
+      "actions": {
+        "Response": {
+          "runAfter": { "UploadAttachment": [ "Succeeded" ] },
+          "type": "Response",
+          "inputs": {
+            "body": "@body('UploadAttachment')?['response']",
+            "statusCode": 200
+          }
+        },
+        "UploadAttachment": {
+          "runAfter": {},
+          "type": "ApiManagement",
+          "inputs": {
+            "api": { "id": "/subscriptions/FAKE9f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/Api-Default-West-Europe/providers/Microsoft.ApiManagement/service/apiminstancename/apis/58985740990a990dd41e5392" },
+            "body": {
+              "attachment": {
+                "data": "@{triggerBody()['data']}",
+                "extension": "@{triggerBody()['extension']}",
+                "filename": "@{triggerBody()['filename']}",
+                "orderNumber": "@{triggerBody()['orderNumber']}"
+              }
+            },
+            "method": "post",
+            "pathTemplate": {
+              "parameters": {},
+              "template": "/api/v1/relacom/rest/UploadAttachment"
+            },
+            "subscriptionKey": "8266eb865e6c440eb007067773e6890b"
+          }
+        }
+      },
+      "outputs": {}
+    },
+    "parameters": {},
+    "endpointsConfiguration": {
+      "workflow": {
+        "outgoingIpAddresses": [
+          { "address": "40.68.222.65" },
+          { "address": "40.68.209.23" },
+          { "address": "13.95.147.65" }
+        ],
+        "accessEndpointIpAddresses": [
+          { "address": "13.95.155.53" },
+          { "address": "52.174.54.218" },
+          { "address": "52.174.49.6" }
+        ]
+      },
+      "connector": { "outgoingIpAddresses": [ { "address": "40.115.50.13" } ] }
+    }
+  },
+  "id": "/subscriptions/FAKE9f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/resourcegroupname/providers/Microsoft.Logic/workflows/INT006_Send_Attachment",
+  "name": "INT006_Send_Attachment",
+  "type": "Microsoft.Logic/workflows",
+  "location": "westeurope"
+}

--- a/LogicAppTemplate.Test/TestFiles/APIMMultipleDiffrent.json
+++ b/LogicAppTemplate.Test/TestFiles/APIMMultipleDiffrent.json
@@ -1,0 +1,128 @@
+﻿{
+  "properties": {
+    "provisioningState": "Succeeded",
+    "createdTime": "2017-02-09T09:10:49.3907663Z",
+    "changedTime": "2017-02-09T11:37:16.6548587Z",
+    "state": "Enabled",
+    "version": "08587149666489087757",
+    "accessEndpoint": "https://prod-24.westeurope.logic.azure.com:443/workflows/x",
+    "definition": {
+      "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {},
+      "triggers": {
+        "request": {
+          "type": "Request",
+          "kind": "Http",
+          "inputs": {
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "properties": {
+                "data": { "type": "string" },
+                "extension": { "type": "string" },
+                "filename": { "type": "string" },
+                "orderNumber": { "type": "string" }
+              },
+              "required": [ "orderNumber", "filename", "extension", "data" ],
+              "type": "object"
+            }
+          }
+        }
+      },
+      "actions": {
+        "Response": {
+          "runAfter": { "UploadAttachment": [ "Succeeded" ] },
+          "type": "Response",
+          "inputs": {
+            "body": "@body('UploadAttachment')?['response']",
+            "statusCode": 200
+          }
+        },
+        "UploadAttachment": {
+          "runAfter": {},
+          "type": "ApiManagement",
+          "inputs": {
+            "api": { "id": "/subscriptions/FAKE9f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/Api-Default-West-Europe/providers/Microsoft.ApiManagement/service/apiminstancename/apis/58985740990a990dd41e5392" },
+            "body": {
+              "attachment": {
+                "data": "@{triggerBody()['data']}",
+                "extension": "@{triggerBody()['extension']}",
+                "filename": "@{triggerBody()['filename']}",
+                "orderNumber": "@{triggerBody()['orderNumber']}"
+              }
+            },
+            "method": "post",
+            "pathTemplate": {
+              "parameters": {},
+              "template": "/api/v1/relacom/rest/UploadAttachment"
+            },
+            "subscriptionKey": "8266eb865e6c440eb007067773e6890b"
+          }
+        },
+        "UploadAttachment2": {
+          "runAfter": {},
+          "type": "ApiManagement",
+          "inputs": {
+            "api": { "id": "/subscriptions/FAKE9f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/APIintegration/providers/Microsoft.ApiManagement/service/otherapiminstancename/apis/78985740990a990dd41e5392" },
+            "body": {
+              "attachment": {
+                "data": "@{triggerBody()['data']}",
+                "extension": "@{triggerBody()['extension']}",
+                "filename": "@{triggerBody()['filename']}",
+                "orderNumber": "@{triggerBody()['orderNumber']}"
+              }
+            },
+            "method": "post",
+            "pathTemplate": {
+              "parameters": {},
+              "template": "/api/v1/relacom/rest/UploadAttachment"
+            },
+            "subscriptionKey": "F266eb865e6c440eb007067773e6890b"
+          }
+        },
+        "UploadAttachment3": {
+          "runAfter": {},
+          "type": "ApiManagement",
+          "inputs": {
+            "api": { "id": "/subscriptions/FAKE9f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/Api-Default-West-Europe/providers/Microsoft.ApiManagement/service/apiminstancename/apis/58985740990a990dd41e5392" },
+            "body": {
+              "attachment": {
+                "data": "@{triggerBody()['data']}",
+                "extension": "@{triggerBody()['extension']}",
+                "filename": "@{triggerBody()['filename']}",
+                "orderNumber": "@{triggerBody()['orderNumber']}"
+              }
+            },
+            "method": "post",
+            "pathTemplate": {
+              "parameters": {},
+              "template": "/api/v1/relacom/rest/UploadAttachment"
+            },
+            "subscriptionKey": "8266eb865e6c440eb007067773e6890b"
+          }
+        }
+      },
+      "outputs": {}
+    },
+    "parameters": {},
+    "endpointsConfiguration": {
+      "workflow": {
+        "outgoingIpAddresses": [
+          { "address": "40.68.222.65" },
+          { "address": "40.68.209.23" },
+          { "address": "13.95.147.65" }
+        ],
+        "accessEndpointIpAddresses": [
+          { "address": "13.95.155.53" },
+          { "address": "52.174.54.218" },
+          { "address": "52.174.49.6" }
+        ]
+      },
+      "connector": { "outgoingIpAddresses": [ { "address": "40.115.50.13" } ] }
+    }
+  },
+  "id": "/subscriptions/FAKE9f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/resourcegroupname/providers/Microsoft.Logic/workflows/INT006_Send_Attachment",
+  "name": "INT006_Send_Attachment",
+  "type": "Microsoft.Logic/workflows",
+  "location": "westeurope"
+}

--- a/LogicAppTemplate.Test/TestFiles/APIMMultipleSame.json
+++ b/LogicAppTemplate.Test/TestFiles/APIMMultipleSame.json
@@ -1,0 +1,107 @@
+﻿{
+  "properties": {
+    "provisioningState": "Succeeded",
+    "createdTime": "2017-02-09T09:10:49.3907663Z",
+    "changedTime": "2017-02-09T11:37:16.6548587Z",
+    "state": "Enabled",
+    "version": "08587149666489087757",
+    "accessEndpoint": "https://prod-24.westeurope.logic.azure.com:443/workflows/x",
+    "definition": {
+      "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {},
+      "triggers": {
+        "request": {
+          "type": "Request",
+          "kind": "Http",
+          "inputs": {
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "properties": {
+                "data": { "type": "string" },
+                "extension": { "type": "string" },
+                "filename": { "type": "string" },
+                "orderNumber": { "type": "string" }
+              },
+              "required": [ "orderNumber", "filename", "extension", "data" ],
+              "type": "object"
+            }
+          }
+        }
+      },
+      "actions": {
+        "Response": {
+          "runAfter": { "UploadAttachment": [ "Succeeded" ] },
+          "type": "Response",
+          "inputs": {
+            "body": "@body('UploadAttachment')?['response']",
+            "statusCode": 200
+          }
+        },
+        "UploadAttachment": {
+          "runAfter": {},
+          "type": "ApiManagement",
+          "inputs": {
+            "api": { "id": "/subscriptions/FAKE9f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/Api-Default-West-Europe/providers/Microsoft.ApiManagement/service/apiminstancename/apis/58985740990a990dd41e5392" },
+            "body": {
+              "attachment": {
+                "data": "@{triggerBody()['data']}",
+                "extension": "@{triggerBody()['extension']}",
+                "filename": "@{triggerBody()['filename']}",
+                "orderNumber": "@{triggerBody()['orderNumber']}"
+              }
+            },
+            "method": "post",
+            "pathTemplate": {
+              "parameters": {},
+              "template": "/api/v1/relacom/rest/UploadAttachment"
+            },
+            "subscriptionKey": "8266eb865e6c440eb007067773e6890b"
+          }
+        },
+        "UploadAttachment2": {
+          "runAfter": {},
+          "type": "ApiManagement",
+          "inputs": {
+            "api": { "id": "/subscriptions/FAKE9f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/Api-Default-West-Europe/providers/Microsoft.ApiManagement/service/apiminstancename/apis/58985740990a990dd41e5392" },
+            "body": {
+              "attachment": {
+                "data": "@{triggerBody()['data']}",
+                "extension": "@{triggerBody()['extension']}",
+                "filename": "@{triggerBody()['filename']}",
+                "orderNumber": "@{triggerBody()['orderNumber']}"
+              }
+            },
+            "method": "post",
+            "pathTemplate": {
+              "parameters": {},
+              "template": "/api/v1/relacom/rest/UploadAttachment"
+            },
+            "subscriptionKey": "8266eb865e6c440eb007067773e6890b"
+          }
+        }
+      },
+      "outputs": {}
+    },
+    "parameters": {},
+    "endpointsConfiguration": {
+      "workflow": {
+        "outgoingIpAddresses": [
+          { "address": "40.68.222.65" },
+          { "address": "40.68.209.23" },
+          { "address": "13.95.147.65" }
+        ],
+        "accessEndpointIpAddresses": [
+          { "address": "13.95.155.53" },
+          { "address": "52.174.54.218" },
+          { "address": "52.174.49.6" }
+        ]
+      },
+      "connector": { "outgoingIpAddresses": [ { "address": "40.115.50.13" } ] }
+    }
+  },
+  "id": "/subscriptions/FAKE9f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/resourcegroupname/providers/Microsoft.Logic/workflows/INT006_Send_Attachment",
+  "name": "INT006_Send_Attachment",
+  "type": "Microsoft.Logic/workflows",
+  "location": "westeurope"
+}

--- a/LogicAppTemplate.Test/TestFiles/Switch.json
+++ b/LogicAppTemplate.Test/TestFiles/Switch.json
@@ -1,0 +1,168 @@
+﻿{
+  "properties": {
+    "provisioningState": "Succeeded",
+    "createdTime": "2017-04-07T06:40:49.6623589Z",
+    "changedTime": "2017-04-12T08:54:55.4081962Z",
+    "state": "Enabled",
+    "version": "08587096195901185904",
+    "accessEndpoint": "https://prod-18.westeurope.logic.azure.com:443/workflows/7f90c7c14bdc4899b779c001b695dc91",
+    "definition": {
+      "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {},
+      "triggers": {
+        "request": {
+          "type": "Request",
+          "kind": "Http",
+          "inputs": {
+            "schema": {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "properties": {
+                "Report_actionCode": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "workorderno": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "workorderno",
+                "Report_actionCode"
+              ],
+              "type": "object"
+            }
+          }
+        }
+      },
+      "actions": {
+        "Condition": {
+          "actions": {
+            "Switch": {
+              "runAfter": {},
+              "cases": {
+                "Case": {
+                  "case": "[",
+                  "actions": {
+                    "For_each": {
+                      "foreach": "@triggerBody()['Report_actionCode']",
+                      "actions": {
+                        "INT002_Create_Actioncode": {
+                          "runAfter": {},
+                          "type": "ApiManagement",
+                          "inputs": {
+                            "api": {
+                              "id": "/subscriptions/af531b7a-d0ff-455d-a2bf-eae0b300696d/resourceGroups/rgname/providers/Microsoft.ApiManagement/service/apiinstance/apis/58778a86990a990f5c794e48"
+                            },
+                            "body": {
+                              "actioncode": "@{item()}",
+                              "workorderno": "@{triggerBody()['workorderno']}"
+                            },
+                            "method": "post",
+                            "pathTemplate": {
+                              "parameters": {},
+                              "template": "/limetest/createactioncode"
+                            },
+                            "subscriptionKey": "fake530567e4e03bb0d21254fo8252b"
+                          }
+                        }
+                      },
+                      "runAfter": {},
+                      "type": "Foreach"
+                    }
+                  }
+                }
+              },
+              "default": {
+                "actions": {
+                  "INT002_Create_Actioncode_2": {
+                    "runAfter": {},
+                    "type": "ApiManagement",
+                    "inputs": {
+                      "api": {
+                        "id": "/subscriptions/af531b7a-d0ff-455d-a2bf-eae0b300696d/resourceGroups/rgname/providers/Microsoft.ApiManagement/service/apiinstance/apis/58778a86990a990f5c794e48"
+                      },
+                      "body": {
+                        "actioncode": "@{triggerBody()['Report_actionCode']}",
+                        "workorderno": "@{triggerBody()['workorderno']}"
+                      },
+                      "method": "post",
+                      "pathTemplate": {
+                        "parameters": {},
+                        "template": "/limetest/createactioncode"
+                      },
+                      "subscriptionKey": "fakec530567e4e03bb0d21254fo8252b"
+                    }
+                  }
+                }
+              },
+              "expression": "@substring(string(coalesce(triggerbody()['Report_actionCode'],'Null')),0,1)",
+              "type": "Switch"
+            }
+          },
+          "runAfter": {},
+          "expression": "@not(equals(triggerBody()['Report_actionCode'], ''))",
+          "type": "If"
+        },
+        "Response": {
+          "runAfter": {
+            "Condition": [
+              "Succeeded"
+            ]
+          },
+          "type": "Response",
+          "inputs": {
+            "body": "@triggerBody()['Report_actionCode']",
+            "statusCode": 200
+          }
+        }
+      },
+      "outputs": {}
+    },
+    "parameters": {},
+    "endpointsConfiguration": {
+      "workflow": {
+        "outgoingIpAddresses": [
+          {
+            "address": "40.68.222.65"
+          },
+          {
+            "address": "40.68.209.23"
+          },
+          {
+            "address": "13.95.147.65"
+          }
+        ],
+        "accessEndpointIpAddresses": [
+          {
+            "address": "13.95.155.53"
+          },
+          {
+            "address": "52.174.54.218"
+          },
+          {
+            "address": "52.174.49.6"
+          }
+        ]
+      },
+      "connector": {
+        "outgoingIpAddresses": [
+          {
+            "address": "40.115.50.13"
+          }
+        ]
+      }
+    }
+  },
+  "id": "/subscriptions/af531b7a-d0ff-455d-a2bf-eae0b300696d/resourceGroups/rgname/providers/Microsoft.Logic/workflows/INT002_Create_Actioncode",
+  "name": "INT002_Create_Actioncode",
+  "type": "Microsoft.Logic/workflows",
+  "location": "westeurope",
+  "tags": {
+    "displayName": "LogicApp",
+    "INTID": "INT002",
+    "SLA": "C3 - Low Priority"
+  }
+}

--- a/LogicAppTemplate.Test/TestFiles/WorkflowTest.json
+++ b/LogicAppTemplate.Test/TestFiles/WorkflowTest.json
@@ -1,0 +1,90 @@
+﻿{
+  "properties": {
+    "provisioningState": "Succeeded",
+    "createdTime": "2017-03-23T12:18:59.9810997Z",
+    "changedTime": "2017-03-23T12:23:36.340751Z",
+    "state": "Enabled",
+    "version": "08587113350694728985",
+    "accessEndpoint": "https://prod-13.westeurope.logic.azure.com:443/workflows/x",
+    "definition": {
+      "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {
+        "$connections": {
+          "defaultValue": {},
+          "type": "Object"
+        }
+      },
+      "triggers": {
+        "Recurrence": {
+          "recurrence": {
+            "frequency": "Hour",
+            "interval": 6
+          },
+          "type": "Recurrence"
+        }
+      },
+      "actions": {
+        "INT0014-NewHires": {
+          "runAfter": { "Parse_JSON": [ "Succeeded" ] },
+          "type": "Workflow",
+          "inputs": {
+            "body": {
+              "Completed_Date_On_or_After": "@{body('Parse_JSON')?['Completed_Date_On_or_After']}",
+              "Completed_Date_On_or_Before": "@{body('Parse_JSON')?['Completed_Date_On_or_Before']}",
+              "Event_Effective_Date_On_or_After": "@{body('Parse_JSON')?['Event_Effective_Date_On_or_After']}",
+              "Event_Effective_Date_On_or_Before": "@{body('Parse_JSON')?['Event_Effective_Date_On_or_Before']}"
+            },
+            "host": {
+              "triggerName": "manual",
+              "workflow": { "id": "/subscriptions/FAKE1e9-15f5-4c85-bb3e-1e108dc79b00/resourceGroups/resourcegroupname/providers/Microsoft.Logic/workflows/INT0014-NewHires" }
+            }
+          }
+        },
+        "Parse_JSON": {
+          "runAfter": { "Get_blob_content": [ "Succeeded" ] },
+          "type": "ParseJson",
+          "inputs": {
+            "content": {
+              "Completed_Date_On_or_After": "@addhours(string(body('Get_blob_content')), -8)",
+              "Completed_Date_On_or_Before": "@addhours(utcnow(), -8)",
+              "Event_Effective_Date_On_or_After": "@startOfMonth(string(body('Get_blob_content')))",
+              "Event_Effective_Date_On_or_Before": "@utcnow()"
+            },
+            "schema": {
+              "properties": {
+                "Completed_Date_On_or_After": { "type": "string" },
+                "Completed_Date_On_or_Before": { "type": "string" },
+                "Event_Effective_Date_On_or_After": { "type": "string" },
+                "Event_Effective_Date_On_or_Before": { "type": "string" }
+              },
+              "type": "object"
+            }
+          }
+        }
+      },
+      "outputs": {}
+    },
+    "parameters": {
+    },
+    "endpointsConfiguration": {
+      "workflow": {
+        "outgoingIpAddresses": [
+          { "address": "40.68.222.65" },
+          { "address": "40.68.209.23" },
+          { "address": "13.95.147.65" }
+        ],
+        "accessEndpointIpAddresses": [
+          { "address": "13.95.155.53" },
+          { "address": "52.174.54.218" },
+          { "address": "52.174.49.6" }
+        ]
+      },
+      "connector": { "outgoingIpAddresses": [ { "address": "40.115.50.13" } ] }
+    }
+  },
+  "id": "/subscriptions/FAKE1e9-15f5-4c85-bb3e-1e108dc79b00/resourceGroups/resourcegroupname/providers/Microsoft.Logic/workflows/INT0014-NewHires-Trigger",
+  "name": "INT0014-NewHires-Trigger",
+  "type": "Microsoft.Logic/workflows",
+  "location": "westeurope"
+}

--- a/LogicAppTemplate.Test/TestFiles/complex-logicapp-if.json
+++ b/LogicAppTemplate.Test/TestFiles/complex-logicapp-if.json
@@ -8,7 +8,7 @@
     "accessEndpoint": "https://prod-07.westeurope.logic.azure.com:443/workflows/4b3e8864909844fdbde6173b12a1f805",
     "integrationAccount": {
       "name": "Prometera_IA",
-      "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/integrationAccounts/Prometera_IA",
+      "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/rgname/providers/Microsoft.Logic/integrationAccounts/Prometera_IA",
       "type": "Microsoft.Logic/integrationAccounts"
     },
     "definition": {
@@ -48,7 +48,7 @@
                 },
                 "host": {
                   "triggerName": "request",
-                  "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT002_Create_Actioncode" }
+                  "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/rgname/providers/Microsoft.Logic/workflows/INT002_Create_Actioncode" }
                 }
               }
             },
@@ -63,7 +63,7 @@
                 },
                 "host": {
                   "triggerName": "request",
-                  "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT007_Update_Report_Status" }
+                  "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/rgname/providers/Microsoft.Logic/workflows/INT007_Update_Report_Status" }
                 }
               }
             }
@@ -102,7 +102,7 @@
             },
             "host": {
               "triggerName": "request",
-              "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT003_Update_Status" }
+              "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/rgname/providers/Microsoft.Logic/workflows/INT003_Update_Status" }
             }
           }
         },
@@ -120,7 +120,7 @@
             },
             "host": {
               "triggerName": "request",
-              "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT005_Add_Attachment" }
+              "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/rgname/providers/Microsoft.Logic/workflows/INT005_Add_Attachment" }
             }
           }
         },
@@ -138,7 +138,7 @@
             },
             "host": {
               "triggerName": "request",
-              "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT005_Add_Attachment" }
+              "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/rgname/providers/Microsoft.Logic/workflows/INT005_Add_Attachment" }
             }
           }
         },
@@ -209,7 +209,7 @@
                     },
                     "host": {
                       "triggerName": "request",
-                      "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT002_Create_Component" }
+                      "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/rgname/providers/Microsoft.Logic/workflows/INT002_Create_Component" }
                     }
                   }
                 }
@@ -274,7 +274,7 @@
       "connector": { "outgoingIpAddresses": [ { "address": "40.115.50.13" } ] }
     }
   },
-  "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT002_Update_Work_Order2",
+  "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/rgname/providers/Microsoft.Logic/workflows/INT002_Update_Work_Order2",
   "name": "INT002_Update_Work_Order2",
   "type": "Microsoft.Logic/workflows",
   "location": "westeurope",

--- a/LogicAppTemplate.Test/TestFiles/complex-logicapp-if.json
+++ b/LogicAppTemplate.Test/TestFiles/complex-logicapp-if.json
@@ -1,0 +1,285 @@
+﻿{
+  "properties": {
+    "provisioningState": "Succeeded",
+    "createdTime": "2016-10-14T10:04:55.2596844Z",
+    "changedTime": "2017-04-10T14:32:03.0365781Z",
+    "state": "Disabled",
+    "version": "08587097721625654344",
+    "accessEndpoint": "https://prod-07.westeurope.logic.azure.com:443/workflows/4b3e8864909844fdbde6173b12a1f805",
+    "integrationAccount": {
+      "name": "Prometera_IA",
+      "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/integrationAccounts/Prometera_IA",
+      "type": "Microsoft.Logic/integrationAccounts"
+    },
+    "definition": {
+      "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {
+        "$connections": {
+          "defaultValue": {},
+          "type": "Object"
+        },
+        "fileConnectorURI": {
+          "defaultValue": "https://fileconnector382fc3e214db444a8bd129da2c4fc7b5.azurewebsites.net",
+          "type": "String"
+        },
+        "logicAppURI": {
+          "defaultValue": "https://prod-01.westeurope.logic.azure.com:443/workflows/b8676f86f60e4dae9b8dd113b23fc9f0/triggers/manual/run?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=Pc5uStKvS3FxBIcEZttg2t6s5PpdYqRe8nPYnqbFDUA",
+          "type": "String"
+        }
+      },
+      "triggers": {
+        "request": {
+          "type": "Request",
+          "kind": "Http",
+          "inputs": { "schema": {} }
+        }
+      },
+      "actions": {
+        "Choose_external_procedure": {
+          "actions": {
+            "INT002_Create_Actioncode": {
+              "runAfter": { "INT007_Update_Report_Status": [ "Succeeded" ] },
+              "type": "Workflow",
+              "inputs": {
+                "body": {
+                  "Report_actionCode": "@outputs('Compose')['actioncode']",
+                  "workorderno": "@outputs('Compose')['workorderno']"
+                },
+                "host": {
+                  "triggerName": "request",
+                  "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT002_Create_Actioncode" }
+                }
+              }
+            },
+            "INT007_Update_Report_Status": {
+              "runAfter": {},
+              "type": "Workflow",
+              "inputs": {
+                "body": {
+                  "product": "@{outputs('Compose')['product']}",
+                  "resultcode": "@{outputs('Compose')['resultcode']}",
+                  "workorderno": "@{outputs('Compose')['workorderno']}"
+                },
+                "host": {
+                  "triggerName": "request",
+                  "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT007_Update_Report_Status" }
+                }
+              }
+            }
+          },
+          "runAfter": { "Compose": [ "Succeeded" ] },
+          "expression": "@or(or(not(equals(outputs('Compose')['resultcode'], '')),not(equals(outputs('Compose')['actioncode'], ''))),or(not(equals(outputs('Compose')['product'], '')),not(equals(coalesce(outputs('XML_2_JSON')?['workOrders']?['header']?['Report_components'], ''), ''))))",
+          "type": "If"
+        },
+        "Compose": {
+          "runAfter": { "XML_2_JSON": [ "Succeeded" ] },
+          "type": "Compose",
+          "inputs": {
+            "Report_booking_date": "@coalesce(outputs('XML_2_JSON')['workOrders']['header']?['Report_booking_date'], '')",
+            "actioncode": "@coalesce(outputs('XML_2_JSON')['workOrders']['header']?['Report_actionCodes']?['Report_actionCode'], outputs('XML_2_JSON')['workOrders']['header']?['Report_actionCodes'], '')",
+            "company": "@outputs('XML_2_JSON')['workOrders']['header']['Company']",
+            "filename": "@concat(concat(outputs('XML_2_JSON')['workOrders']['workOrder']['code'],'_'), outputs('XML_2_JSON')['workOrders']['header']['messageDate'])",
+            "messagedate": "@outputs('XML_2_JSON')['workOrders']['header']['messageDate']",
+            "product": "@outputs('XML_2_JSON')['workOrders']['header']['Report_product']",
+            "resultcode": "@coalesce(outputs('XML_2_JSON')['workOrders']['header']?['Report_resultCode'], '')",
+            "statuscomment": "@outputs('XML_2_JSON')['workOrders']['header']['Report_status_comment']",
+            "statusdate": "@outputs('XML_2_JSON')['workOrders']['header']['Report_status_date']",
+            "statusid": "@outputs('XML_2_JSON')['workOrders']['header']['Report_status_ID']",
+            "workorderno": "@outputs('XML_2_JSON')['workOrders']['workOrder']['code']"
+          }
+        },
+        "INT003_Update_Status": {
+          "runAfter": { "Compose": [ "Succeeded" ] },
+          "type": "Workflow",
+          "inputs": {
+            "body": {
+              "bookingdate": "@outputs('Compose')['Report_booking_date']",
+              "statuscomment": "@outputs('Compose')['statuscomment']",
+              "statusdate": "@outputs('Compose')['statusdate']",
+              "statusid": "@outputs('Compose')['statusid']",
+              "workorderid": "@outputs('Compose')['workorderno']"
+            },
+            "host": {
+              "triggerName": "request",
+              "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT003_Update_Status" }
+            }
+          }
+        },
+        "INT005_Add_Attachment": {
+          "runAfter": { "Compose": [ "Succeeded" ] },
+          "type": "Workflow",
+          "inputs": {
+            "body": {
+              "company": null,
+              "fileextension": "xml",
+              "filename": "@outputs('Compose')['filename']",
+              "id": null,
+              "image64": "@base64(triggerbody())",
+              "workorderno": "@outputs('Compose')['workorderno']"
+            },
+            "host": {
+              "triggerName": "request",
+              "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT005_Add_Attachment" }
+            }
+          }
+        },
+        "INT005_Add_Attachment_2": {
+          "runAfter": { "Transform_XML": [ "Succeeded" ] },
+          "type": "Workflow",
+          "inputs": {
+            "body": {
+              "company": null,
+              "fileextension": "html",
+              "filename": "@outputs('Compose')['filename']",
+              "id": null,
+              "image64": "@base64(body('Transform_XML'))",
+              "workorderno": "@outputs('Compose')['workorderno']"
+            },
+            "host": {
+              "triggerName": "request",
+              "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT005_Add_Attachment" }
+            }
+          }
+        },
+        "Send_overall_Response": {
+          "runAfter": { "XML_2_JSON": [ "Succeeded" ] },
+          "type": "Response",
+          "inputs": {
+            "body": "Overall Ok",
+            "statusCode": 200
+          }
+        },
+        "Status_Check": {
+          "actions": {
+            "Company_Check": {
+              "actions": {
+                "Create_file_KNAB": {
+                  "runAfter": {},
+                  "type": "ApiConnection",
+                  "inputs": {
+                    "body": "@body('Workorder_2_Workorder')",
+                    "host": {
+                      "api": { "runtimeUrl": "https://logic-apis-westeurope.azure-apim.net/apim/filesystem" },
+                      "connection": { "name": "@parameters('$connections')['filesystem']['connectionId']" }
+                    },
+                    "method": "post",
+                    "path": "/datasets/default/files",
+                    "queries": {
+                      "folderPath": "//pmfs02/ARBETSORDER/RELACOM_TEST/XML_IMPORT/GenerisKNAB",
+                      "name": "@{concat(concat(guid(),'_'), outputs('Compose')['workorderno'])}.xml"
+                    }
+                  }
+                }
+              },
+              "runAfter": { "Workorder_2_Workorder": [ "Succeeded" ] },
+              "else": {
+                "actions": {
+                  "Create_file_OKAB": {
+                    "runAfter": {},
+                    "type": "ApiConnection",
+                    "inputs": {
+                      "body": "@body('Workorder_2_Workorder')",
+                      "host": {
+                        "api": { "runtimeUrl": "https://logic-apis-westeurope.azure-apim.net/apim/filesystem" },
+                        "connection": { "name": "@parameters('$connections')['filesystem']['connectionId']" }
+                      },
+                      "method": "post",
+                      "path": "/datasets/default/files",
+                      "queries": {
+                        "folderPath": "//pmfs02/ARBETSORDER/RELACOM_TEST/XML_IMPORT/GenerisOKAB",
+                        "name": "@{concat(concat(guid(),'_'), outputs('Compose')['workorderno'])}.xml"
+                      }
+                    }
+                  }
+                }
+              },
+              "expression": "@equals(outputs('Compose')['company'], 'KNAB')",
+              "type": "If"
+            },
+            "Component_check": {
+              "actions": {
+                "INT002_Create_Component": {
+                  "runAfter": {},
+                  "type": "Workflow",
+                  "inputs": {
+                    "body": {
+                      "Report_components": "@outputs('XML_2_JSON')['workOrders']['header']['Report_components']",
+                      "workorderno": "@outputs('Compose')['workorderno']"
+                    },
+                    "host": {
+                      "triggerName": "request",
+                      "workflow": { "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT002_Create_Component" }
+                    }
+                  }
+                }
+              },
+              "runAfter": {},
+              "expression": "@not(equals(coalesce(outputs('XML_2_JSON')?['workOrders']?['header']?['Report_components'], ''), ''))",
+              "type": "If"
+            },
+            "Workorder_2_Workorder": {
+              "runAfter": { "Component_check": [ "Succeeded" ] },
+              "type": "Xslt",
+              "inputs": {
+                "content": "@{triggerBody()}",
+                "integrationAccount": { "map": { "name": "workorder_2_workorder" } }
+              }
+            }
+          },
+          "runAfter": { "Compose": [ "Succeeded" ] },
+          "expression": "@or(equals(outputs('Compose')['statusid'], '60'), equals(outputs('XML_2_JSON')['workOrders']['header']['Report_status_ID'], '70'))",
+          "type": "If"
+        },
+        "Transform_XML": {
+          "runAfter": { "Compose": [ "Succeeded" ] },
+          "type": "Xslt",
+          "inputs": {
+            "content": "@{triggerBody()}",
+            "integrationAccount": { "map": { "name": "workorder_2_html" } }
+          }
+        },
+        "XML_2_JSON": {
+          "runAfter": {},
+          "type": "Compose",
+          "inputs": "@json(triggerbody())"
+        }
+      },
+      "outputs": {
+        "StaticInformation": {
+          "type": "String",
+          "value": "test"
+        },
+        "WorkOrderNumber": {
+          "type": "String",
+          "value": "@outputs('XML_2_JSON')['workOrders']['workOrder']['code']"
+        }
+      }
+    },
+    "parameters": {      
+    },
+    "endpointsConfiguration": {
+      "workflow": {
+        "outgoingIpAddresses": [
+          { "address": "40.68.222.65" },
+          { "address": "40.68.209.23" },
+          { "address": "13.95.147.65" }
+        ],
+        "accessEndpointIpAddresses": [
+          { "address": "13.95.155.53" },
+          { "address": "52.174.54.218" },
+          { "address": "52.174.49.6" }
+        ]
+      },
+      "connector": { "outgoingIpAddresses": [ { "address": "40.115.50.13" } ] }
+    }
+  },
+  "id": "/subscriptions/ecda89f1-660a-4585-b4d8-bf5172cb7f70/resourceGroups/integration-we/providers/Microsoft.Logic/workflows/INT002_Update_Work_Order2",
+  "name": "INT002_Update_Work_Order2",
+  "type": "Microsoft.Logic/workflows",
+  "location": "westeurope",
+  "tags": {
+    "INTID": "INT002",
+    "SLA": "C2 - High Priority"
+  }
+}

--- a/LogicAppTemplate.Test/TestFiles/integrationaccount.json
+++ b/LogicAppTemplate.Test/TestFiles/integrationaccount.json
@@ -1,0 +1,75 @@
+﻿{
+  "properties": {
+    "provisioningState": "Succeeded",
+    "createdTime": "2017-01-20T11:23:58.3674648Z",
+    "changedTime": "2017-03-30T14:34:58.4847948Z",
+    "state": "Enabled",
+    "version": "08587107223872362421",
+    "accessEndpoint": "https://prod-00.westeurope.logic.azure.com:443/workflows/x",
+    "integrationAccount": {
+      "name": "ia-tst",
+      "id": "/subscriptions/FAKEa1e9-15f5-4c85-bb3e-1e108dc79b01/resourcegroups/resourcegroupname/providers/Microsoft.Logic/integrationAccounts/ia-tst",
+      "type": "Microsoft.Logic/integrationAccounts"
+    },
+    "definition": {
+      "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {},
+      "triggers": {
+        "request": {
+          "type": "Request",
+          "kind": "Http",
+          "inputs": { "schema": {} }
+        }
+      },
+      "actions": {
+        "Flat_File_Encoding": {
+          "runAfter": { "Transform_XML": [ "Succeeded" ] },
+          "type": "FlatFileEncoding",
+          "inputs": {
+            "content": "@{body('Transform_XML')}",
+            "integrationAccount": { "schema": { "name": "INT0010-Navision.Transfer" } }
+          }
+        },
+        "Response": {
+          "runAfter": { "Flat_File_Encoding": [ "Succeeded" ] },
+          "type": "Response",
+          "inputs": {
+            "body": "@body('Flat_File_Encoding')",
+            "statusCode": 200
+          }
+        },
+        "Transform_XML": {
+          "runAfter": {},
+          "type": "Xslt",
+          "inputs": {
+            "content": "@{triggerBody()}",
+            "integrationAccount": { "map": { "name": "INT0010-Alusta.TransferToNavision.Transfer" } }
+          }
+        }
+      },
+      "outputs": {}
+    },
+    "parameters": {},
+    "endpointsConfiguration": {
+      "workflow": {
+        "outgoingIpAddresses": [
+          { "address": "40.68.222.65" },
+          { "address": "40.68.209.23" },
+          { "address": "13.95.147.65" }
+        ],
+        "accessEndpointIpAddresses": [
+          { "address": "13.95.155.53" },
+          { "address": "52.174.54.218" },
+          { "address": "52.174.49.6" }
+        ]
+      },
+      "connector": { "outgoingIpAddresses": [ { "address": "40.115.50.13" } ] }
+    }
+  },
+  "id": "/subscriptions/FAKEa1e9-15f5-4c85-bb3e-1e108dc79b01/resourceGroups/resourcegroupname/providers/Microsoft.Logic/workflows/INT0010-Transfer",
+  "name": "INT0010-Transfer",
+  "type": "Microsoft.Logic/workflows",
+  "location": "westeurope",
+  "tags": { "displayName": "LogicApp" }
+}

--- a/LogicAppTemplate.Test/TestFiles/paramGeneratorLogicAppTemplate.json
+++ b/LogicAppTemplate.Test/TestFiles/paramGeneratorLogicAppTemplate.json
@@ -1,0 +1,130 @@
+﻿{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "logicAppName": {
+      "type": "string",
+      "defaultValue": "INT0014-NewHires-Trigger",
+      "metadata": {
+        "description": "Name of the Logic App."
+      }
+    },
+    "logicAppLocation": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "allowedValues": [
+        "eastasia",
+        "southeastasia",
+        "centralus",
+        "eastus",
+        "eastus2",
+        "westus",
+        "northcentralus",
+        "southcentralus",
+        "northeurope",
+        "westeurope",
+        "japanwest",
+        "japaneast",
+        "brazilsouth",
+        "australiaeast",
+        "australiasoutheast",
+        "westcentralus",
+        "westus2"
+      ],
+      "metadata": {
+        "description": "Location of the Logic App."
+      }
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Logic/workflows",
+      "apiVersion": "2016-06-01",
+      "name": "[parameters('logicAppName')]",
+      "location": "[parameters('logicAppLocation')]",
+      "dependsOn": [],
+      "properties": {
+        "definition": {
+          "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "$connections": {
+              "defaultValue": {},
+              "type": "Object"
+            }
+          },
+          "triggers": {
+            "Recurrence": {
+              "recurrence": {
+                "frequency": "Hour",
+                "interval": 6
+              },
+              "type": "Recurrence"
+            }
+          },
+          "actions": {
+            "INT0014-NewHires": {
+              "runAfter": {
+                "Parse_JSON": [
+                  "Succeeded"
+                ]
+              },
+              "type": "Workflow",
+              "inputs": {
+                "body": {
+                  "Completed_Date_On_or_After": "@{body('Parse_JSON')?['Completed_Date_On_or_After']}",
+                  "Completed_Date_On_or_Before": "@{body('Parse_JSON')?['Completed_Date_On_or_Before']}",
+                  "Event_Effective_Date_On_or_After": "@{body('Parse_JSON')?['Event_Effective_Date_On_or_After']}",
+                  "Event_Effective_Date_On_or_Before": "@{body('Parse_JSON')?['Event_Effective_Date_On_or_Before']}"
+                },
+                "host": {
+                  "triggerName": "manual",
+                  "workflow": {
+                    "id": "[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', resourceGroup().name,'/providers/Microsoft.Logic/workflows/INT0014-NewHires')]"
+                  }
+                }
+              }
+            },
+            "Parse_JSON": {
+              "runAfter": {
+                "Get_blob_content": [
+                  "Succeeded"
+                ]
+              },
+              "type": "ParseJson",
+              "inputs": {
+                "content": {
+                  "Completed_Date_On_or_After": "@addhours(string(body('Get_blob_content')), -8)",
+                  "Completed_Date_On_or_Before": "@addhours(utcnow(), -8)",
+                  "Event_Effective_Date_On_or_After": "@startOfMonth(string(body('Get_blob_content')))",
+                  "Event_Effective_Date_On_or_Before": "@utcnow()"
+                },
+                "schema": {
+                  "properties": {
+                    "Completed_Date_On_or_After": {
+                      "type": "string"
+                    },
+                    "Completed_Date_On_or_Before": {
+                      "type": "string"
+                    },
+                    "Event_Effective_Date_On_or_After": {
+                      "type": "string"
+                    },
+                    "Event_Effective_Date_On_or_Before": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "outputs": {}
+        },
+        "parameters": {}
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/LogicAppTemplate/Constants/Constants.cs
+++ b/LogicAppTemplate/Constants/Constants.cs
@@ -11,7 +11,8 @@ namespace LogicAppTemplate
     public static class Constants
     {
         internal static readonly string deploymentSchema = @"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#";
-     
+        internal static readonly string parameterSchema = @"https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#";
+
         public static string AuthString = "https://login.windows.net/common/oauth2/authorize";
         public static string ClientId = "1950a258-227b-4e31-a9cf-717495945fc2";
         public static string ResourceUrl = "https://management.core.windows.net/";

--- a/LogicAppTemplate/Constants/Constants.cs
+++ b/LogicAppTemplate/Constants/Constants.cs
@@ -12,67 +12,6 @@ namespace LogicAppTemplate
     {
         internal static readonly string deploymentSchema = @"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#";
      
-
-
-        internal static readonly string deploymentTemplate = @"{
-  ""$schema"": ""https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"",
-  ""contentVersion"": ""1.0.0.0"",
-  ""parameters"": {
-    ""logicAppName"": {
-      ""type"": ""string""
-    },
-    ""logicAppLocation"": {
-      ""type"": ""string"",
-      ""defaultValue"": ""[resourceGroup().location]"",
-      ""allowedValues"": [
-        ""eastasia"",
-        ""southeastasia"",
-        ""centralus"",
-        ""eastus"",
-        ""eastus2"",
-        ""westus"",
-        ""northcentralus"",
-        ""southcentralus"",
-        ""northeurope"",
-        ""westeurope"",
-        ""japanwest"",
-        ""japaneast"",
-        ""brazilsouth"",
-        ""australiaeast"",
-        ""australiasoutheast"",
-        ""southindia"",
-        ""centralindia"",
-        ""westindia"",
-        ""canadacentral"",
-        ""canadaeast"",
-        ""westcentralus"",
-        ""westus2"",
-        ""[resourceGroup().location]""
-      ],
-      ""metadata"": {
-        ""description"": ""Location of the Logic App.""
-      }
-    }
-  },
-  ""variables"": {
-  },
-  ""resources"": [
-    {
-      ""type"": ""Microsoft.Logic/workflows"",
-      ""apiVersion"": ""2016-06-01"",
-      ""name"": ""[parameters('logicAppName')]"",
-      ""dependsOn"": [],
-      ""location"": ""[parameters('logicAppLocation')]"",
-      ""properties"": {
-        ""definition"": { },
-        ""parameters"": { }
-      }
-    }
-  ],
-  ""outputs"": { }
-}
-";
-
         public static string AuthString = "https://login.windows.net/common/oauth2/authorize";
         public static string ClientId = "1950a258-227b-4e31-a9cf-717495945fc2";
         public static string ResourceUrl = "https://management.core.windows.net/";

--- a/LogicAppTemplate/LogicAppTemplate.csproj
+++ b/LogicAppTemplate/LogicAppTemplate.csproj
@@ -59,6 +59,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Constants\Constants.cs" />
+    <Compile Include="Models\ParameterTemplate.cs" />
+    <Compile Include="ParamGenerator.cs" />
     <Compile Include="TemplateGenerator.cs" />
     <Compile Include="Models\ConnectionTemplate.cs" />
     <Compile Include="Models\DeploymentTemplate.cs" />
@@ -67,6 +69,7 @@
   <ItemGroup>
     <None Include="packages.config" />
     <EmbeddedResource Include="Templates\starterTemplate.json" />
+    <EmbeddedResource Include="Templates\paramTemplate.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/LogicAppTemplate/LogicAppTemplate.csproj
+++ b/LogicAppTemplate/LogicAppTemplate.csproj
@@ -66,7 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="Templates\starterTemplate.json" />
+    <EmbeddedResource Include="Templates\starterTemplate.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/LogicAppTemplate/Models/ParameterTemplate.cs
+++ b/LogicAppTemplate/Models/ParameterTemplate.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogicAppTemplate.Models
+{
+    public class ParameterTemplate
+    {
+        [JsonProperty("$schema")]
+        public string schema
+        {
+            get
+            {
+                return Constants.parameterSchema;
+            }
+        }
+        public string contentVersion
+        {
+            get
+            {
+                return "1.0.0.0";
+            }
+        }
+
+        public JObject parameters { get; set; }
+    }
+}

--- a/LogicAppTemplate/ParamGenerator.cs
+++ b/LogicAppTemplate/ParamGenerator.cs
@@ -1,0 +1,59 @@
+﻿using LogicAppTemplate.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogicAppTemplate
+{
+    [Cmdlet(VerbsCommon.Get, "ParameterTemplate", ConfirmImpact = ConfirmImpact.None)]
+    public class ParamGenerator : PSCmdlet
+    {
+        [Parameter(
+            Mandatory = true,
+            HelpMessage = "The path to the template file"
+            )]
+        public string TemplateFile;
+
+
+        private ParameterTemplate paramTemplate;
+        public ParamGenerator()
+        {
+
+            var assembly = System.Reflection.Assembly.GetExecutingAssembly();
+            var resourceName = "LogicAppTemplate.Templates.paramTemplate.json";
+            using (Stream stream = assembly.GetManifestResourceStream(resourceName))
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                paramTemplate = JsonConvert.DeserializeObject<ParameterTemplate>(reader.ReadToEnd());
+            }
+        }
+
+        protected override void ProcessRecord()
+        {
+
+            var logicappTemplate = JObject.Parse(File.ReadAllText(TemplateFile));
+            var result = CreateParameterFileFromTemplate(logicappTemplate);
+            
+
+            WriteObject(result.ToString());
+        }
+
+        public JObject CreateParameterFileFromTemplate(JObject logicAppTemplate)
+        {
+            foreach(var param in logicAppTemplate["parameters"].Children<JProperty>())
+            {
+                var obj = new JObject();
+                obj["value"] = logicAppTemplate["parameters"][param.Name]["defaultValue"];
+                paramTemplate.parameters.Add(param.Name, obj);
+            }
+
+            return JObject.FromObject(paramTemplate);
+        }
+    }
+}

--- a/LogicAppTemplate/TemplateGenerator.cs
+++ b/LogicAppTemplate/TemplateGenerator.cs
@@ -146,12 +146,14 @@ namespace LogicAppTemplate
             var matches = rgx.Match(definition.Value<string>("id"));
             LogicAppResourceGroup = matches.Groups["resourcegroup"].Value;
 
+            template.parameters["logicAppName"]["defaultValue"] = definition.Value<string>("name");
+
             workflowTemplateReference = template.resources.Where(t => ((string)t["type"]) == "Microsoft.Logic/workflows").FirstOrDefault();
 
             // WriteVerbose("Upgrading connectionId paramters...");
             var modifiedDefinition = definition["properties"]["definition"].ToString().Replace(@"['connectionId']", @"['connectionId']");
             // WriteVerbose("Removing API Host references...");
-            template.parameters["logicAppLocation"]["defaultValue"] = definition["location"];
+            //template.parameters["logicAppLocation"]["defaultValue"] = definition["location"];
 
             workflowTemplateReference["properties"]["definition"] = handleActions(JObject.Parse(modifiedDefinition));
 

--- a/LogicAppTemplate/Templates/paramTemplate.json
+++ b/LogicAppTemplate/Templates/paramTemplate.json
@@ -1,0 +1,7 @@
+﻿{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    
+  }
+}

--- a/LogicAppTemplate/Templates/starterTemplate.json
+++ b/LogicAppTemplate/Templates/starterTemplate.json
@@ -4,6 +4,7 @@
   "parameters": {
     "logicAppName": {
       "type": "string",
+      "defaultValue": "",
       "metadata": {
         "description": "Name of the Logic App."
       }

--- a/LogicAppTemplate/Templates/starterTemplate.json
+++ b/LogicAppTemplate/Templates/starterTemplate.json
@@ -3,23 +3,71 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "logicAppName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Logic App."
+      }
+
+    },
+    "logicAppLocation": {
+      "type": "string",
+      "defaultValue": "westeurope",
+      "allowedValues": [
+        "eastasia",
+        "southeastasia",
+        "centralus",
+        "eastus",
+        "eastus2",
+        "westus",
+        "northcentralus",
+        "southcentralus",
+        "northeurope",
+        "westeurope",
+        "japanwest",
+        "japaneast",
+        "brazilsouth",
+        "australiaeast",
+        "australiasoutheast",
+        "westcentralus",
+        "westus2",
+        "[resourceGroup().location]"
+      ],
+      "metadata": {
+        "description": "Location of the Logic App."
+      }
+    },
+    "IntegrationAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Integration Account that should be connected to this Logic App."
+      },
+      "defaultValue": ""
+    },
+    "IntegrationAccountResourceGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource group name that the Integration Account are in"
+      },
+      "defaultValue": "[resourceGroup().location]"
     }
   },
   "variables": {
   },
   "resources": [
-   {
+    {
       "type": "Microsoft.Logic/workflows",
       "apiVersion": "2016-06-01",
       "name": "[parameters('logicAppName')]",
       "location": "[resourceGroup().location]",
-      "dependsOn": [ ],
+      "dependsOn": [],
       "properties": {
-        "definition": { },
-        "parameters": { }
+        "definition": {},
+        "parameters": {},
+        "integrationAccount": {
+          "id": "[concat('/subscriptions/',subscription().subscriptionId,'/resourcegroups/',parameters('IntegrationAccountResourceGroupName'),'/providers/Microsoft.Logic/integrationAccounts/',parameters('IntegrationAccountName'))]"
+        }
       }
     }
   ],
-  "outputs": { }
+  "outputs": {}
 }

--- a/LogicAppTemplate/Templates/starterTemplate.json
+++ b/LogicAppTemplate/Templates/starterTemplate.json
@@ -11,7 +11,7 @@
     },
     "logicAppLocation": {
       "type": "string",
-      "defaultValue": "westeurope",
+      "defaultValue": "[resourceGroup().location]",
       "allowedValues": [
         "eastasia",
         "southeastasia",
@@ -29,8 +29,7 @@
         "australiaeast",
         "australiasoutheast",
         "westcentralus",
-        "westus2",
-        "[resourceGroup().location]"
+        "westus2"
       ],
       "metadata": {
         "description": "Location of the Logic App."
@@ -48,7 +47,7 @@
       "metadata": {
         "description": "The resource group name that the Integration Account are in"
       },
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().id]"
     }
   },
   "variables": {

--- a/LogicAppTemplate/Templates/starterTemplate.json
+++ b/LogicAppTemplate/Templates/starterTemplate.json
@@ -48,7 +48,7 @@
       "metadata": {
         "description": "The resource group name that the Integration Account are in"
       },
-      "defaultValue": "[resourceGroup().id]"
+      "defaultValue": "[resourceGroup().name]"
     }
   },
   "variables": {
@@ -58,7 +58,7 @@
       "type": "Microsoft.Logic/workflows",
       "apiVersion": "2016-06-01",
       "name": "[parameters('logicAppName')]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('logicAppLocation')]",
       "dependsOn": [],
       "properties": {
         "definition": {},

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Clone the project, open, and build.
 
 Open PowerShell and Import the module:
 
-`Import-Module C:\{pathToSolution}\LogicAppTemplateCreator\LogicAppTemplate\bin\Debug\ConverterLibrary.dll`
+`Import-Module C:\{pathToSolution}\LogicAppTemplateCreator\LogicAppTemplate\bin\Debug\LogicAppTemplate.dll`
 
 Run the PowerShell command `Get-LogicAppTemplate`.  You can pipe the output as needed, and recommended you pipe in a token from `armclient`
 
 `armclient token 80d4fe69-xxxx-4dd2-a938-9250f1c8ab03 | Get-LogicAppTemplate -LogicApp MyApp -ResourceGroup Integrate2016 -SubscriptionId 80d4fe69-xxxx-4dd2-a938-9250f1c8ab03 -Verbose | Out-File C:\template.json`
 
-Example when user is connected to multitenants
+Example when user is connected to multitenants:
 Get-LogicAppTemplate -LogicApp MyApp -ResourceGroup Integrate2016 -SubscriptionId 80d4fe69-xxxx-4dd2-a938-9250f1c8ab03 -TenantName contoso.onmicrosoft.com
 
 ### Specifications
@@ -27,3 +27,13 @@ Get-LogicAppTemplate -LogicApp MyApp -ResourceGroup Integrate2016 -SubscriptionI
 | TenantName | Name of the Tenant i.e. contoso.onmicrosoft.com | false |
 | Token | An AAD Token to access the resources - should not include `Bearer`, only the token | false |
 | ClaimsDump | A dump of claims piped in from `armclient` - should not be manually set | false |
+
+
+After extraction a parameters file can be created off the LogicAppTemplate. (works on any ARM template file):
+Get-ParameterTemplate -TemplateFile $filenname | Out-File 'paramfile.json'
+
+### Specifications
+
+| Parameter | Description | Required |
+| --------- | ---------- | -------|
+| TemplateFile | File path to the template file | true |


### PR DESCRIPTION
Extraction updates that will split up the "hard coded" links that is generated by the designer.
This update are used to make sure the ARM template is deployable in any subscription witout the need of changing static variables as subscriptionid or resourcegroups.

Making urls as:
"workflow": { "id": "/subscriptions/FAKE1e9-15f5-4c85-bb3e-1e108dc79b00/resourceGroups/resourcegroupname/providers/Microsoft.Logic/workflows/INT0014-NewHires" }
to generic:
 "workflow": {
                    "id": "[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/', resourceGroup().name,'/providers/Microsoft.Logic/workflows/INT0014-NewHires')]"
                  }

Supports nested conditions,loops etc.
Supports API Management, Functions and Workflows.

Promoting API Management parameters to the arm template to make sure that subscription key, instance name and resource group is configured correctly

Added a bunch of test files and test possibilites, fixed som smaller issues such as putting the name of the logic app as the default value name of the Logic App.


Added a new function Get-ParamterTemplate that creates a parameter file from the ARM template, just with the default values.

