### PR TITLE
Cleaning a duplicate entry of packages.config

### DIFF
--- a/LogicAppTemplate/LogicAppTemplate.csproj
+++ b/LogicAppTemplate/LogicAppTemplate.csproj
@@ -72,7 +72,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Cmdlets\Get-RGLogicAppsTemplate.ps1" />
-    <None Include="packages.config" />
     <EmbeddedResource Include="Templates\starterTemplate.json" />
     <EmbeddedResource Include="Templates\paramTemplate.json" />
     <EmbeddedResource Include="Templates\nestedTemplateResource.json" />


### PR DESCRIPTION
The last sync worked well, the only glitch (which didn't impact the build) was two entries in the LogicAppTemplate.csproj pointing to the same file - packages.config. I've removed one of the entries from the project, and reload. Project still builds correctly and packages.config with the right values is still there. Should be safe to merge.
