### PR TITLE
Corrected case where parameter string default value is null

### DIFF
--- a/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
+++ b/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
@@ -105,6 +105,7 @@
     <EmbeddedResource Include="TestFiles\Samples\CustomConnector\providers-Microsoft.Logic-workflows-INT001.Invoice.json" />
     <EmbeddedResource Include="TestFiles\Samples\CustomConnector\providers-Microsoft.Web-connections-Billogram.json" />
     <EmbeddedResource Include="TestFiles\Samples\CustomConnector\providers-Microsoft.Web-customApis-Billogram.json" />
+    <EmbeddedResource Include="TestFiles\paramGenerator-nullString.json" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/LogicAppTemplate.Test/ParamGeneratorTests.cs
+++ b/LogicAppTemplate.Test/ParamGeneratorTests.cs
@@ -70,9 +70,18 @@ namespace LogicAppTemplate.Test
             Assert.AreEqual("sql-1_password", defintion["parameters"]["sql-1_password"]["reference"]["secretName"]);
         }
 
+        [TestMethod]
+        public void GenerateParameterFileWithNullString()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.paramGenerator-nullString.json");
+            var generator = new ParamGenerator();
+            generator.KeyVault = ParamGenerator.KeyVaultUsage.Static;
+            var defintion = generator.CreateParameterFileFromTemplate(JObject.Parse(content));
 
-
-
+            // Check parameters
+            Assert.AreEqual("SQLAzure", (string)defintion["parameters"]["logicAppName"]["value"]);
+            Assert.IsNull((string)defintion["parameters"]["sql-1_name"]["value"]);
+        }
 
         //var resourceName = "LogicAppTemplate.Templates.starterTemplate.json";
         private static string GetEmbededFileContent(string resourceName)

--- a/LogicAppTemplate.Test/TestFiles/paramGenerator-nullString.json
+++ b/LogicAppTemplate.Test/TestFiles/paramGenerator-nullString.json
@@ -1,0 +1,155 @@
+﻿{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "logicAppName": {
+      "type": "string",
+      "defaultValue": "SQLAzure",
+      "metadata": {
+        "description": "Name of the Logic App."
+      }
+    },
+    "logicAppLocation": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "allowedValues": [
+        "[resourceGroup().location]",
+        "eastasia",
+        "southeastasia",
+        "centralus",
+        "eastus",
+        "eastus2",
+        "westus",
+        "northcentralus",
+        "southcentralus",
+        "northeurope",
+        "westeurope",
+        "japanwest",
+        "japaneast",
+        "brazilsouth",
+        "australiaeast",
+        "australiasoutheast",
+        "westcentralus",
+        "westus2"
+      ],
+      "metadata": {
+        "description": "Location of the Logic App."
+      }
+    },
+    "sql-1_name": {
+      "type": "string",
+      "defaultValue": null
+    },
+    "sql-1_displayName": {
+      "type": "string",
+      "defaultValue": "SQL Azure"
+    },
+    "sql-1_server": {
+      "type": "string",
+      "defaultValue": "dummyserverone.database.windows.net",
+      "metadata": {
+        "description": "SQL server name"
+      }
+    },
+    "sql-1_database": {
+      "type": "string",
+      "defaultValue": "dummydatabase",
+      "metadata": {
+        "description": "SQL database name"
+      }
+    },
+    "sql-1_username": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Username credential"
+      }
+    },
+    "sql-1_password": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Password credential"
+      }
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Logic/workflows",
+      "apiVersion": "2016-06-01",
+      "name": "[parameters('logicAppName')]",
+      "location": "[parameters('logicAppLocation')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/connections', parameters('sql-1_name'))]"
+      ],
+      "properties": {
+        "definition": {
+          "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "$connections": {
+              "defaultValue": {},
+              "type": "Object"
+            }
+          },
+          "triggers": {
+            "manual": {
+              "type": "Request",
+              "kind": "Http",
+              "inputs": {
+                "schema": {}
+              }
+            }
+          },
+          "actions": {
+            "Get_rows": {
+              "runAfter": {},
+              "type": "ApiConnection",
+              "inputs": {
+                "host": {
+                  "connection": {
+                    "name": "@parameters('$connections')['sql_1']['connectionId']"
+                  }
+                },
+                "method": "get",
+                "path": "/datasets/default/tables/@{encodeURIComponent(encodeURIComponent('[SalesLT].[Customer]'))}/items"
+              }
+            }
+          },
+          "outputs": {}
+        },
+        "parameters": {
+          "$connections": {
+            "value": {
+              "sql_1": {
+                "id": "[concat(subscription().id,'/providers/Microsoft.Web/locations/', parameters('logicAppLocation'), '/managedApis/sql')]",
+                "connectionId": "[resourceId('Microsoft.Web/connections', parameters('sql-1_name'))]",
+                "connectionName": "[parameters('sql-1_name')]"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Web/connections",
+      "apiVersion": "2016-06-01",
+      "location": "[parameters('logicAppLocation')]",
+      "name": "[parameters('sql-1_name')]",
+      "properties": {
+        "api": {
+          "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', parameters('logicAppLocation'), '/managedApis/', 'sql')]"
+        },
+        "displayName": "[parameters('sql-1_displayName')]",
+        "parameterValues": {
+          "server": "[parameters('sql-1_server')]",
+          "database": "[parameters('sql-1_database')]",
+          "username": "[parameters('sql-1_username')]",
+          "password": "[parameters('sql-1_password')]"
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/LogicAppTemplate/ParamGenerator.cs
+++ b/LogicAppTemplate/ParamGenerator.cs
@@ -61,7 +61,7 @@ namespace LogicAppTemplate
             foreach(var param in logicAppTemplate["parameters"].Children<JProperty>())
             {
                 // Don't create parameters that reference a ARM Template expression
-                if (param.Value.Value<string>("type").Equals("string",StringComparison.CurrentCultureIgnoreCase) && param.Value.Value<string>("defaultValue").StartsWith("["))
+                if (param.Value.Value<string>("type").Equals("string",StringComparison.CurrentCultureIgnoreCase) && param.Value.Value<string>("defaultValue") != null  && param.Value.Value<string>("defaultValue").StartsWith("["))
                 {
                     continue;
                 }


### PR DESCRIPTION
When extracting a Logic App with defaultValue = null for parameter string type an exception is thrown. Added a correction to take care of this. Example that caused the error: 

"INT123-SFTP_sshHostKeyFingerprint": {
      "type": "string",
      "defaultValue": null,
      "metadata": {
        "description": "SSH Host Key Finger-print"
      }
},