### PR TITLE
The parameter $connections name should be used instead of the connectionName

### DIFF
--- a/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
+++ b/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
@@ -108,6 +108,7 @@
     <EmbeddedResource Include="TestFiles\paramGenerator-nullString.json" />
     <EmbeddedResource Include="TestFiles\Samples\DiagnosticSettings\providers-Microsoft.Logic-workflows-INT001.Invoice.json" />
     <EmbeddedResource Include="TestFiles\Samples\DiagnosticSettings\providers-Microsoft.Logic-workflows-INT001.Invoice-providers-microsoft.insights-diagnosticSettings.json" />
+    <EmbeddedResource Include="TestFiles\AzureBlobWithDifferentNameThanConnectionName.json" />
   </ItemGroup>
   <ItemGroup />
   <Choose>

--- a/LogicAppTemplate.Test/TemplateGeneratorTests.cs
+++ b/LogicAppTemplate.Test/TemplateGeneratorTests.cs
@@ -444,6 +444,19 @@ namespace LogicAppTemplate.Tests
             Assert.AreEqual("[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('azureblob_accountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]", defintion["properties"]["parameterValues"]["accessKey"]);
             Assert.AreEqual("[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', parameters('logicAppLocation'), '/managedApis/azureblob')]", defintion["properties"]["api"]["id"]);
         }
+
+        [TestMethod()]
+        public void TestBlobConnectionWithDifferentNameThanConnectionName()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.AzureBlobWithDifferentNameThanConnectionName.json");
+
+            var generator = new TemplateGenerator("lanme", "fakeee-15f5-4c85-bb3e-1e108dc79b00", "", null);
+
+            var defintion = generator.generateDefinition(JObject.Parse(content), false).GetAwaiter().GetResult();
+
+            Assert.IsNotNull(defintion["resources"][0]["properties"]["parameters"]["$connections"]["value"]["azureblob_1"]);
+        }
+
         [TestMethod()]
         public void TestBlobAction()
         {

--- a/LogicAppTemplate.Test/TestFiles/AzureBlobWithDifferentNameThanConnectionName.json
+++ b/LogicAppTemplate.Test/TestFiles/AzureBlobWithDifferentNameThanConnectionName.json
@@ -1,0 +1,186 @@
+﻿{
+  "properties": {
+    "provisioningState": "Succeeded",
+    "createdTime": "2017-03-23T12:18:59.9810997Z",
+    "changedTime": "2017-08-21T11:55:21.1998435Z",
+    "state": "Enabled",
+    "version": "08586982903643342035",
+    "accessEndpoint": "https://prod-13.westeurope.logic.azure.com:443/workflows/714b7261a41b49abb021e7dda9df4aae",
+    "definition": {
+      "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {
+        "$connections": {
+          "defaultValue": {},
+          "type": "Object"
+        }
+      },
+      "triggers": {
+        "Recurrence": {
+          "recurrence": {
+            "frequency": "Day",
+            "interval": 1,
+            "schedule": {
+              "hours": [
+                2
+              ],
+              "minutes": [
+                10
+              ]
+            },
+            "startTime": "2017-06-01T01:40:00.5116371Z",
+            "timeZone": "UTC"
+          },
+          "type": "Recurrence",
+          "operationOptions": "SingleInstance"
+        }
+      },
+      "actions": {
+        "Condition": {
+          "actions": {
+            "Get_blob_content": {
+              "runAfter": {},
+              "metadata": {
+                "L2ludDAwMTQvRGF0ZS5qc29u": "/int0014/Date.json"
+              },
+              "type": "ApiConnection",
+              "inputs": {
+                "host": {
+                  "connection": {
+                    "name": "@parameters('$connections')['azureblob_1']['connectionId']"
+                  }
+                },
+                "method": "get",
+                "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent('L2ludDAwMTQvRGF0ZS5qc29u'))}/content",
+                "queries": {
+                  "inferContentType": true
+                }
+              }
+            },
+            "INT0014-NewHires": {
+              "runAfter": {
+                "Parse_JSON": [
+                  "Succeeded"
+                ]
+              },
+              "type": "Workflow",
+              "inputs": {
+                "body": {
+                  "Completed_Date_On_or_After": "@{body('Parse_JSON')?['Start_Date']}",
+                  "Completed_Date_On_or_Before": "@{body('Parse_JSON')?['End_Date']}"
+                },
+                "host": {
+                  "triggerName": "manual",
+                  "workflow": {
+                    "id": "/subscriptions/fakeee-15f5-4c85-bb3e-1e108dc79b00/resourceGroups/myresourcegroup/providers/Microsoft.Logic/workflows/INT0014-NewHires"
+                  }
+                },
+                "retryPolicy": {
+                  "type": "none"
+                }
+              }
+            },
+            "Parse_JSON": {
+              "runAfter": {
+                "Get_blob_content": [
+                  "Succeeded"
+                ]
+              },
+              "type": "ParseJson",
+              "inputs": {
+                "content": {
+                  "End_Date": "@utcnow()",
+                  "Start_Date": "@startOfDay(string(body('Get_blob_content')))"
+                },
+                "schema": {
+                  "properties": {
+                    "End_Date": {
+                      "type": "string"
+                    },
+                    "Start_Date": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "Update_blob": {
+              "runAfter": {
+                "INT0014-NewHires": [
+                  "Succeeded"
+                ]
+              },
+              "metadata": {
+                "L2ludDAwMTQvRGF0ZS5qc29u": "/int0014/Date.json"
+              },
+              "type": "ApiConnection",
+              "inputs": {
+                "body": "@body('Parse_JSON')?['End_Date']",
+                "host": {
+                  "connection": {
+                    "name": "@parameters('$connections')['azureblob_1']['connectionId']"
+                  }
+                },
+                "method": "put",
+                "path": "/datasets/default/files/@{encodeURIComponent(encodeURIComponent('L2ludDAwMTQvRGF0ZS5qc29u'))}"
+              }
+            }
+          },
+          "runAfter": {},
+          "expression": "@contains('12345', string(dayOfWeek(addhours(utcnow(), 2))))",
+          "type": "If"
+        }
+      },
+      "outputs": {}
+    },
+    "parameters": {
+      "$connections": {
+        "value": {
+          "azureblob_1": {
+            "connectionId": "/subscriptions/fakeee-15f5-4c85-bb3e-1e108dc79b00/resourceGroups/myresourcegroup/providers/Microsoft.Web/connections/azureblob-1",
+            "connectionName": "azureblob-1",
+            "id": "/subscriptions/fakeee-15f5-4c85-bb3e-1e108dc79b00/providers/Microsoft.Web/locations/westeurope/managedApis/azureblob"
+          }
+        }
+      }
+    },
+    "endpointsConfiguration": {
+      "workflow": {
+        "outgoingIpAddresses": [
+          {
+            "address": "40.68.222.65"
+          },
+          {
+            "address": "40.68.209.23"
+          },
+          {
+            "address": "13.95.147.65"
+          }
+        ],
+        "accessEndpointIpAddresses": [
+          {
+            "address": "13.95.155.53"
+          },
+          {
+            "address": "52.174.54.218"
+          },
+          {
+            "address": "52.174.49.6"
+          }
+        ]
+      },
+      "connector": {
+        "outgoingIpAddresses": [
+          {
+            "address": "40.115.50.13"
+          }
+        ]
+      }
+    }
+  },
+  "id": "/subscriptions/fakeee-15f5-4c85-bb3e-1e108dc79b00/resourceGroups/myresourcegroup/providers/Microsoft.Logic/workflows/INT0014-NewHires-Trigger",
+  "name": "INT0014-NewHires-Trigger",
+  "type": "Microsoft.Logic/workflows",
+  "location": "westeurope"
+}

--- a/LogicAppTemplate/TemplateGenerator.cs
+++ b/LogicAppTemplate/TemplateGenerator.cs
@@ -54,7 +54,7 @@ namespace LogicAppTemplate
         {
             JObject _definition = await resourceCollector.GetResource($"https://management.azure.com/subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroup}/providers/Microsoft.Logic/workflows/{LogicApp}", "2016-06-01");
             return await generateDefinition(_definition);
-        }        
+        }
 
         public async Task<JObject> generateDefinition(JObject definition, bool generateConnection = true)
         {
@@ -129,20 +129,20 @@ namespace LogicAppTemplate
                 string name = connectionProperty.Name;
                 string connectionId = connectionProperty.First.Value<string>("connectionId");
                 string id = connectionProperty.First.Value<string>("id");
-                string connectionName = connectionProperty.First["connectionName"] != null ? connectionProperty.First.Value<string>("connectionName"): connectionId.Split('/').Last();
+                string connectionName = connectionProperty.First["connectionName"] != null ? connectionProperty.First.Value<string>("connectionName") : connectionId.Split('/').Last();
 
                 var cid = apiIdTemplate(id);
                 string concatedId = $"[concat('{cid.ToString()}')]";
                 //fixes old templates where name sometimes is missing
 
                 var connectionNameParam = AddTemplateParameter($"{connectionName}_name", "string", connectionName);
-                workflowTemplateReference["properties"]["parameters"]["$connections"]["value"][connectionName] = JObject.FromObject(new
+                workflowTemplateReference["properties"]["parameters"]["$connections"]["value"][name] = JObject.FromObject(new
                 {
-                    id = concatedId, 
+                    id = concatedId,
                     connectionId = $"[resourceId('Microsoft.Web/connections', parameters('{connectionNameParam}'))]",
                     connectionName = $"[parameters('{connectionNameParam}')]"
                 });
-                
+
                 /*
                 "connections_Billogram_id": {
                     "defaultValue": "/subscriptions/cb693348-19cf-42ee-9a63-1969d567f333/resourceGroups/Shared/providers/Microsoft.Web/customApis/Billogram",
@@ -215,7 +215,7 @@ namespace LogicAppTemplate
             foreach (JObject resourceProperty in resources["value"])
             {
                 string dsName = AddTemplateParameter(Constants.DsName, "string", resourceProperty["name"]);
-                
+
                 Match m = Regex.Match((string)resourceProperty["properties"]["workspaceId"], "resourceGroups/(.*)/providers/Microsoft.OperationalInsights/workspaces/(.*)", RegexOptions.IgnoreCase);
 
                 string dsResourceGroup = AddTemplateParameter(Constants.DsResourceGroup, "string", m.Groups[1].Value);
@@ -241,17 +241,18 @@ namespace LogicAppTemplate
         {
             var rid = new AzureResourceId(apiId);
             rid.SubscriptionId = "',subscription().subscriptionId,'";
-            if(apiId.Contains("/managedApis/"))
+            if (apiId.Contains("/managedApis/"))
             {
-                rid.ReplaceValueAfter("locations", "',parameters('logicAppLocation'),'");                
-            }else
+                rid.ReplaceValueAfter("locations", "',parameters('logicAppLocation'),'");
+            }
+            else
             {
-                
+
                 string resourcegroupValue = LogicAppResourceGroup == rid.ResourceGroupName ? "[resourceGroup().name]" : rid.ResourceGroupName;
                 string resourcegroupParameterName = AddTemplateParameter(apiId.Split('/').Last() + "-ResourceGroup", "string", resourcegroupValue);
                 rid.ResourceGroupName = $"',parameters('{resourcegroupParameterName}'),'";
             }
-            return rid; 
+            return rid;
         }
 
 
@@ -267,7 +268,7 @@ namespace LogicAppTemplate
                 {
                     var curr = ((JObject)definition["actions"][action.Name]["inputs"]["host"]["workflow"]).Value<string>("id");
                     ///subscriptions/fakeecb73-15f5-4c85-bb3e-fakeecb73/resourceGroups/myresourcegrp/providers/Microsoft.Logic/workflows/INT0020-All-Users-Batch2
-                    var wid = new AzureResourceId(curr);                    
+                    var wid = new AzureResourceId(curr);
                     string resourcegroupValue = LogicAppResourceGroup == wid.ResourceGroupName ? "[resourceGroup().name]" : wid.ResourceGroupName;
                     string resourcegroupParameterName = AddTemplateParameter(action.Name + "-ResourceGroup", "string", resourcegroupValue);
                     string wokflowParameterName = AddTemplateParameter(action.Name + "-LogicAppName", "string", wid.ResourceName);
@@ -279,7 +280,7 @@ namespace LogicAppTemplate
                 {
                     var apiId = ((JObject)definition["actions"][action.Name]["inputs"]["api"]).Value<string>("id");
                     var aaid = new AzureResourceId(apiId);
-                   
+
 
                     aaid.SubscriptionId = "',subscription().subscriptionId,'";
                     aaid.ResourceGroupName = "', parameters('" + AddTemplateParameter("apimResourceGroup", "string", aaid.ResourceGroupName) + "'),'";
@@ -597,14 +598,14 @@ namespace LogicAppTemplate
             return realParameterName;
         }
 
-      
-        
-        public JObject generateConnectionTemplate(JObject connectionResource, JObject connectionInstance, string connectionName,string concatedId, string connectionNameParam)
+
+
+        public JObject generateConnectionTemplate(JObject connectionResource, JObject connectionInstance, string connectionName, string concatedId, string connectionNameParam)
         {
             //create template
-            var connectionTemplate = new Models.ConnectionTemplate(connectionNameParam, concatedId);           
+            var connectionTemplate = new Models.ConnectionTemplate(connectionNameParam, concatedId);
             //displayName            
-            connectionTemplate.properties.displayName = $"[parameters('{AddTemplateParameter(connectionName+ "_displayName", "string", (string)connectionInstance["properties"]["displayName"])}')]";
+            connectionTemplate.properties.displayName = $"[parameters('{AddTemplateParameter(connectionName + "_displayName", "string", (string)connectionInstance["properties"]["displayName"])}')]";
             JObject connectionParameters = new JObject();
 
             bool useGateway = connectionInstance["properties"]["nonSecretParameterValues"]["gateway"] != null;
@@ -666,7 +667,7 @@ namespace LogicAppTemplate
 
             if (useGateway)
             {
-                var currentvalue = (string)connectionInstance["properties"]["nonSecretParameterValues"]["gateway"]["id"];     
+                var currentvalue = (string)connectionInstance["properties"]["nonSecretParameterValues"]["gateway"]["id"];
                 var rid = new AzureResourceId(currentvalue);
                 var gatewayname = AddTemplateParameter($"{connectionName}_gatewayname", "string", rid.ResourceName);
                 var resourcegroup = AddTemplateParameter($"{connectionName}_gatewayresourcegroup", "string", rid.ResourceGroupName);

--- a/LogicAppTemplate/TemplateGenerator.cs
+++ b/LogicAppTemplate/TemplateGenerator.cs
@@ -54,7 +54,7 @@ namespace LogicAppTemplate
         {
             JObject _definition = await resourceCollector.GetResource($"https://management.azure.com/subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroup}/providers/Microsoft.Logic/workflows/{LogicApp}", "2016-06-01");
             return await generateDefinition(_definition);
-        }
+        }        
 
         public async Task<JObject> generateDefinition(JObject definition, bool generateConnection = true)
         {
@@ -129,7 +129,7 @@ namespace LogicAppTemplate
                 string name = connectionProperty.Name;
                 string connectionId = connectionProperty.First.Value<string>("connectionId");
                 string id = connectionProperty.First.Value<string>("id");
-                string connectionName = connectionProperty.First["connectionName"] != null ? connectionProperty.First.Value<string>("connectionName") : connectionId.Split('/').Last();
+                string connectionName = connectionProperty.First["connectionName"] != null ? connectionProperty.First.Value<string>("connectionName"): connectionId.Split('/').Last();
 
                 var cid = apiIdTemplate(id);
                 string concatedId = $"[concat('{cid.ToString()}')]";
@@ -138,11 +138,11 @@ namespace LogicAppTemplate
                 var connectionNameParam = AddTemplateParameter($"{connectionName}_name", "string", connectionName);
                 workflowTemplateReference["properties"]["parameters"]["$connections"]["value"][name] = JObject.FromObject(new
                 {
-                    id = concatedId,
+                    id = concatedId, 
                     connectionId = $"[resourceId('Microsoft.Web/connections', parameters('{connectionNameParam}'))]",
                     connectionName = $"[parameters('{connectionNameParam}')]"
                 });
-
+                
                 /*
                 "connections_Billogram_id": {
                     "defaultValue": "/subscriptions/cb693348-19cf-42ee-9a63-1969d567f333/resourceGroups/Shared/providers/Microsoft.Web/customApis/Billogram",
@@ -215,7 +215,7 @@ namespace LogicAppTemplate
             foreach (JObject resourceProperty in resources["value"])
             {
                 string dsName = AddTemplateParameter(Constants.DsName, "string", resourceProperty["name"]);
-
+                
                 Match m = Regex.Match((string)resourceProperty["properties"]["workspaceId"], "resourceGroups/(.*)/providers/Microsoft.OperationalInsights/workspaces/(.*)", RegexOptions.IgnoreCase);
 
                 string dsResourceGroup = AddTemplateParameter(Constants.DsResourceGroup, "string", m.Groups[1].Value);
@@ -241,18 +241,17 @@ namespace LogicAppTemplate
         {
             var rid = new AzureResourceId(apiId);
             rid.SubscriptionId = "',subscription().subscriptionId,'";
-            if (apiId.Contains("/managedApis/"))
+            if(apiId.Contains("/managedApis/"))
             {
-                rid.ReplaceValueAfter("locations", "',parameters('logicAppLocation'),'");
-            }
-            else
+                rid.ReplaceValueAfter("locations", "',parameters('logicAppLocation'),'");                
+            }else
             {
-
+                
                 string resourcegroupValue = LogicAppResourceGroup == rid.ResourceGroupName ? "[resourceGroup().name]" : rid.ResourceGroupName;
                 string resourcegroupParameterName = AddTemplateParameter(apiId.Split('/').Last() + "-ResourceGroup", "string", resourcegroupValue);
                 rid.ResourceGroupName = $"',parameters('{resourcegroupParameterName}'),'";
             }
-            return rid;
+            return rid; 
         }
 
 
@@ -268,7 +267,7 @@ namespace LogicAppTemplate
                 {
                     var curr = ((JObject)definition["actions"][action.Name]["inputs"]["host"]["workflow"]).Value<string>("id");
                     ///subscriptions/fakeecb73-15f5-4c85-bb3e-fakeecb73/resourceGroups/myresourcegrp/providers/Microsoft.Logic/workflows/INT0020-All-Users-Batch2
-                    var wid = new AzureResourceId(curr);
+                    var wid = new AzureResourceId(curr);                    
                     string resourcegroupValue = LogicAppResourceGroup == wid.ResourceGroupName ? "[resourceGroup().name]" : wid.ResourceGroupName;
                     string resourcegroupParameterName = AddTemplateParameter(action.Name + "-ResourceGroup", "string", resourcegroupValue);
                     string wokflowParameterName = AddTemplateParameter(action.Name + "-LogicAppName", "string", wid.ResourceName);
@@ -280,7 +279,7 @@ namespace LogicAppTemplate
                 {
                     var apiId = ((JObject)definition["actions"][action.Name]["inputs"]["api"]).Value<string>("id");
                     var aaid = new AzureResourceId(apiId);
-
+                   
 
                     aaid.SubscriptionId = "',subscription().subscriptionId,'";
                     aaid.ResourceGroupName = "', parameters('" + AddTemplateParameter("apimResourceGroup", "string", aaid.ResourceGroupName) + "'),'";
@@ -598,14 +597,14 @@ namespace LogicAppTemplate
             return realParameterName;
         }
 
-
-
-        public JObject generateConnectionTemplate(JObject connectionResource, JObject connectionInstance, string connectionName, string concatedId, string connectionNameParam)
+      
+        
+        public JObject generateConnectionTemplate(JObject connectionResource, JObject connectionInstance, string connectionName,string concatedId, string connectionNameParam)
         {
             //create template
-            var connectionTemplate = new Models.ConnectionTemplate(connectionNameParam, concatedId);
+            var connectionTemplate = new Models.ConnectionTemplate(connectionNameParam, concatedId);           
             //displayName            
-            connectionTemplate.properties.displayName = $"[parameters('{AddTemplateParameter(connectionName + "_displayName", "string", (string)connectionInstance["properties"]["displayName"])}')]";
+            connectionTemplate.properties.displayName = $"[parameters('{AddTemplateParameter(connectionName+ "_displayName", "string", (string)connectionInstance["properties"]["displayName"])}')]";
             JObject connectionParameters = new JObject();
 
             bool useGateway = connectionInstance["properties"]["nonSecretParameterValues"]["gateway"] != null;
@@ -667,7 +666,7 @@ namespace LogicAppTemplate
 
             if (useGateway)
             {
-                var currentvalue = (string)connectionInstance["properties"]["nonSecretParameterValues"]["gateway"]["id"];
+                var currentvalue = (string)connectionInstance["properties"]["nonSecretParameterValues"]["gateway"]["id"];     
                 var rid = new AzureResourceId(currentvalue);
                 var gatewayname = AddTemplateParameter($"{connectionName}_gatewayname", "string", rid.ResourceName);
                 var resourcegroup = AddTemplateParameter($"{connectionName}_gatewayresourcegroup", "string", rid.ResourceGroupName);


### PR DESCRIPTION
The problem happens when the connectionName is different than the parameter $connections name. In my case the parameter $connections name was "azureblob_1", but the connectionName was "azureblob-1". The workflow definition itself refers to the parameter $connections name (azureblob_1), so I changed the parameter $connection to use that instead of connectionName. I added a test file with a new test for this scenario as well.