### PR TITLE
Generate templates for integration account schemas

### DIFF
--- a/LogicAppTemplate/GeneratorIAMapCmdlet.cs
+++ b/LogicAppTemplate/GeneratorIAMapCmdlet.cs
@@ -15,6 +15,9 @@ namespace LogicAppTemplate
         [Parameter(Mandatory = true, HelpMessage = "Name of the Artifact")]
         public string ArtifactName;
 
+        [Parameter(Mandatory = false, HelpMessage = "Type of Artifact")]
+        public IntegrationAccountGenerator.ARtifactType ArtifactType = IntegrationAccountGenerator.ARtifactType.Maps;
+
         [Parameter(Mandatory = true, HelpMessage = "Name of the IntegrationAccount")]
         public string IntegrationAccount;
 
@@ -63,7 +66,7 @@ namespace LogicAppTemplate
             {
                 return;
             }
-            IntegrationAccountGenerator generator = new IntegrationAccountGenerator(ArtifactName,IntegrationAccountGenerator.ARtifactType.Maps, IntegrationAccount, SubscriptionId, ResourceGroup,resourceCollector);
+            IntegrationAccountGenerator generator = new IntegrationAccountGenerator(ArtifactName, ArtifactType, IntegrationAccount, SubscriptionId, ResourceGroup, resourceCollector);
 
             try
             {

--- a/LogicAppTemplate/GeneratorIASchemaCmdlet.cs
+++ b/LogicAppTemplate/GeneratorIASchemaCmdlet.cs
@@ -7,8 +7,8 @@ using System.Windows.Forms;
 
 namespace LogicAppTemplate
 {
-    [Cmdlet(VerbsCommon.Get, "IntegrationAccountMapTemplate", ConfirmImpact = ConfirmImpact.None)]
-    public class GeneratorIAMapCmdlet : PSCmdlet
+    [Cmdlet(VerbsCommon.Get, "IntegrationAccountSchemaTemplate", ConfirmImpact = ConfirmImpact.None)]
+    public class GeneratorIASchemaCmdlet : PSCmdlet
     {
         [Parameter(Mandatory = true, HelpMessage = "Name of the Artifact")]
         public string ArtifactName;
@@ -61,7 +61,7 @@ namespace LogicAppTemplate
             {
                 return;
             }
-            IntegrationAccountGenerator generator = new IntegrationAccountGenerator(ArtifactName, IntegrationAccountGenerator.ARtifactType.Maps, IntegrationAccount, SubscriptionId, ResourceGroup, resourceCollector);
+            IntegrationAccountGenerator generator = new IntegrationAccountGenerator(ArtifactName, IntegrationAccountGenerator.ARtifactType.Schemas, IntegrationAccount, SubscriptionId, ResourceGroup, resourceCollector);
 
             try
             {

--- a/LogicAppTemplate/IntegrationAccountGenerator.cs
+++ b/LogicAppTemplate/IntegrationAccountGenerator.cs
@@ -51,15 +51,20 @@ namespace LogicAppTemplate
             //add the current Integration Account parameter name
             var location = template.AddParameter("integrationAccountLocation", "string", "[resourceGroup().location]");
             obj.location = "[parameters('integrationAccountLocation')]";
-            
 
-
-            obj.properties["mapType"] = resource["properties"]["mapType"];
-            obj.properties["parametersSchema"] = resource["properties"]["parametersSchema"];
+            if (type == ARtifactType.Maps)
+            {
+                obj.properties["mapType"] = resource["properties"]["mapType"];
+                obj.properties["parametersSchema"] = resource["properties"]["parametersSchema"];
+                obj.properties["contentType"] = obj.properties.Value<string>("mapType") == "Liquid" ? "text/plain" : "application/xml";
+            }
+            else if (type == ARtifactType.Schemas)
+            {
+                obj.properties["schemaType"] = resource["properties"]["schemaType"];
+                obj.properties["contentType"] = "application/xml";
+            }
 
             obj.properties["content"] = rawresource;
-            obj.properties["contentType"] = obj.properties.Value <string>("mapType") == "Liquid" ? "text/plain" : "application/xml";
-
 
             template.resources.Add(JObject.FromObject( obj));
 

--- a/LogicAppTemplate/LogicAppTemplate.csproj
+++ b/LogicAppTemplate/LogicAppTemplate.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Constants\Constants.cs" />
     <Compile Include="EmptyParameterTemplateGenerator.cs" />
     <Compile Include="GeneratorCustomConnectorCmdlet.cs" />
+    <Compile Include="GeneratorIASchemaCmdlet.cs" />
     <Compile Include="GeneratorIAMapCmdlet.cs" />
     <Compile Include="GeneratorCmdlet.cs" />
     <Compile Include="CustomConnectorGenerator.cs" />


### PR DESCRIPTION
Hi!

I added a new parameter "ArtifactType" to Get-IntegrationAccountMapTemplate to make it possible to generate templates for Schemas. I made it optional and kept the default as "Maps" to not break existing scripts.

Example:
```powershell
Get-IntegrationAccountMapTemplate -ArtifactType Schemas
```

Best regards,
Ludvig Falck

