### PR TITLE
There is not always a metadata property. If not return currentValue

### DIFF
--- a/LogicAppTemplate/TemplateGenerator.cs
+++ b/LogicAppTemplate/TemplateGenerator.cs
@@ -486,7 +486,7 @@ namespace LogicAppTemplate
             var meta = action.Value<JObject>("metadata");
 
             if (meta == null)
-                return "";
+                return currentValue;
 
             var inputs = action.Value<JObject>("inputs");
 


### PR DESCRIPTION
There is not always a metadata property. Therefor my path gets a empty result. This is not correct.

Now when default return currentValue instead of string.empty

