### PR TITLE
DiagnosticSettings as switch parameter

### DIFF
--- a/LogicAppTemplate/GeneratorCmdlet.cs
+++ b/LogicAppTemplate/GeneratorCmdlet.cs
@@ -34,7 +34,7 @@ namespace LogicAppTemplate
         public string DebugOutPutFolder = "";
 
         [Parameter(Mandatory = false, HelpMessage = "If true, diagnostic settings will be included in the ARM template")]
-        public bool DiagnosticSettings = false;
+        public SwitchParameter DiagnosticSettings;
 
         protected override void ProcessRecord()
         {


### PR DESCRIPTION
From a powershell perspective, it makes most sense that when we have bool parameters that are default false, they should be of the type SwitchParameter.

This enables the user to just add the parameter as a switch, instead of having to add the parameter and parse $true to them.

E.g.
-DiagnosticSettings:$true
becomes
-DiagnosticSettings

This implementation should be more consistent with the powershell paradigm and it is actually mentioned in the docs that we should try to use the SwitchParameter instead of bool / boolean.

https://docs.microsoft.com/en-us/powershell/developer/cmdlet/types-of-cmdlet-parameters#switch-parameters