### PR TITLE
Implement clear parameter value

### DIFF
--- a/LogicAppTemplate.Test/ParamGeneratorTests.cs
+++ b/LogicAppTemplate.Test/ParamGeneratorTests.cs
@@ -25,7 +25,22 @@ namespace LogicAppTemplate.Test
             //check parameters
             Assert.IsNull(defintion["parameters"]["INT0014-NewHires-ResourceGroup"]);
             Assert.IsNull(defintion["parameters"]["logicAppLocation"]);
+
+            Assert.AreNotEqual(defintion["parameters"]["logicAppName"]["value"], "");
             Assert.AreEqual("INT0014-NewHires-Trigger", defintion["parameters"]["logicAppName"]["value"]);
+        }
+
+        [TestMethod]
+        public void GenerateParameterFileFromTemplateClearVariables()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.paramGeneratorLogicAppTemplate.json");
+            var generator = new ParamGenerator();
+            generator.ClearParameterValues = true;
+            var defintion = generator.CreateParameterFileFromTemplate(JObject.Parse(content));
+
+            //check parameters
+            Assert.IsNotNull(defintion["parameters"]["logicAppName"]);
+            Assert.AreEqual(defintion["parameters"]["logicAppName"]["value"], "");
         }
 
         [TestMethod]

--- a/LogicAppTemplate.Test/ParamGeneratorTests.cs
+++ b/LogicAppTemplate.Test/ParamGeneratorTests.cs
@@ -26,7 +26,7 @@ namespace LogicAppTemplate.Test
             Assert.IsNull(defintion["parameters"]["INT0014-NewHires-ResourceGroup"]);
             Assert.IsNull(defintion["parameters"]["logicAppLocation"]);
 
-            Assert.AreNotEqual(defintion["parameters"]["logicAppName"]["value"], "");
+            Assert.AreNotEqual(defintion["parameters"]["logicAppName"]["value"].ToString(), "[]");
             Assert.AreEqual("INT0014-NewHires-Trigger", defintion["parameters"]["logicAppName"]["value"]);
         }
 

--- a/LogicAppTemplate.Test/ParamGeneratorTests.cs
+++ b/LogicAppTemplate.Test/ParamGeneratorTests.cs
@@ -40,7 +40,7 @@ namespace LogicAppTemplate.Test
 
             //check parameters
             Assert.IsNotNull(defintion["parameters"]["logicAppName"]);
-            Assert.AreEqual(defintion["parameters"]["logicAppName"]["value"], "");
+            Assert.AreEqual(defintion["parameters"]["logicAppName"]["value"].ToString(), "[]");
         }
 
         [TestMethod]

--- a/LogicAppTemplate/ParamGenerator.cs
+++ b/LogicAppTemplate/ParamGenerator.cs
@@ -27,6 +27,9 @@ namespace LogicAppTemplate
             )]
         public KeyVaultUsage KeyVault = KeyVaultUsage.None;
 
+        [Parameter(Mandatory = false, HelpMessage = "If true, the default value for the parameters will be cleared")]
+        public SwitchParameter ClearParameterValues;
+
         public enum KeyVaultUsage
         {
             None,
@@ -74,6 +77,10 @@ namespace LogicAppTemplate
                     k.keyVault.id = "/subscriptions/{subscriptionid}/resourceGroups/{resourcegroupname}/providers/Microsoft.KeyVault/vaults/{vault-name}";
                     k.secretName = param.Name;
                     obj["reference"] = JObject.FromObject(k);                    
+                }
+                else if (ClearParameterValues)
+                {
+                    obj["value"] = string.Empty;
                 }
                 else {
                     obj["value"] = logicAppTemplate["parameters"][param.Name]["defaultValue"];

--- a/LogicAppTemplate/ParamGenerator.cs
+++ b/LogicAppTemplate/ParamGenerator.cs
@@ -80,7 +80,7 @@ namespace LogicAppTemplate
                 }
                 else if (ClearParameterValues)
                 {
-                    obj["value"] = string.Empty;
+                    obj["value"] = JValue.Parse("[]");
                 }
                 else {
                     obj["value"] = logicAppTemplate["parameters"][param.Name]["defaultValue"];


### PR DESCRIPTION
To support the scenario where you want to be 100% sure that you don't leak sensitive / semi-sensitive data from your development.

Will simply assign an empty "[]" json property value to the defaultvalue.

Contains:
1 x Unit test to test that it works like expected

1 x modification of existing unit test, to validate that the change didn't break anything.
