### PR TITLE
Implement update parameter reference

### DIFF
--- a/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
+++ b/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
@@ -60,6 +60,7 @@
     <Compile Include="AzureResourceIdTests.cs" />
     <Compile Include="IntegrationAccountTest.cs" />
     <Compile Include="BlobConnector2Test.cs" />
+    <Compile Include="ParamGeneratorTests.cs" />
     <Compile Include="StorageQueueConnectorTest.cs" />
     <Compile Include="ExpressionTest.cs" />
     <Compile Include="CustomConnectorTest.cs" />
@@ -68,7 +69,7 @@
     <Compile Include="BlobConnectorTest.cs" />
     <Compile Include="EventGridConnectorTest.cs" />
     <Compile Include="TemplateGeneratorTests.cs" />
-    <Compile Include="ParamGeneratorTests.cs" />
+    <Compile Include="VariableUpdaterTests.cs" />
     <Compile Include="TableConnectorTest.cs" />
     <Compile Include="Utils.cs" />
   </ItemGroup>
@@ -144,6 +145,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <EmbeddedResource Include="TestFiles\VariableReference.json" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/LogicAppTemplate.Test/TestFiles/VariableReference.json
+++ b/LogicAppTemplate.Test/TestFiles/VariableReference.json
@@ -1,0 +1,400 @@
+﻿{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "logicAppName": {
+      "type": "string",
+      "defaultValue": "test",
+      "metadata": {
+        "description": "Name of the Logic App."
+      }
+    },
+    "logicAppLocation": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "allowedValues": [
+        "[resourceGroup().location]",
+        "eastasia",
+        "southeastasia",
+        "centralus",
+        "eastus",
+        "eastus2",
+        "westus",
+        "northcentralus",
+        "southcentralus",
+        "northeurope",
+        "westeurope",
+        "japanwest",
+        "japaneast",
+        "brazilsouth",
+        "australiaeast",
+        "australiasoutheast",
+        "westcentralus",
+        "westus2"
+      ],
+      "metadata": {
+        "description": "Location of the Logic App."
+      }
+    },
+    "HTTP-URI": {
+      "type": "string",
+      "defaultValue": "@{variables('URL')}_vti_bin/DN/DataService.svc/CurrencyRatesXML?lang=da"
+    },
+    "Initialize-Array-Value-Value": {
+      "type": "array",
+      "defaultValue": [
+        "red",
+        "orange",
+        "yellow"
+      ]
+    },
+    "Initialize-Boolean-False-Value": {
+      "type": "bool",
+      "defaultValue": false
+    },
+    "Initialize-Boolean-False-Expression-Value": {
+      "type": "string",
+      "defaultValue": "@false"
+    },
+    "Initialize-Boolean-True-Value": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "Initialize-Boolean-True-Expression-Value": {
+      "type": "string",
+      "defaultValue": "@true"
+    },
+    "Initialize-Float-0.01-Value": {
+      "type": "string",
+      "defaultValue": "0.01"
+    },
+    "Initialize-Integer-0-Value": {
+      "type": "int",
+      "defaultValue": 0
+    },
+    "Initialize-Object-Value-Value": {
+      "type": "object",
+      "defaultValue": {
+        "Test": "Test"
+      }
+    },
+    "Initialize-String-Null-Code-Value": {
+      "type": "string",
+      "defaultValue": "@null"
+    },
+    "Initialize-String-Null-Expression-Value": {
+      "type": "string",
+      "defaultValue": "@{null}"
+    },
+    "Initialize_variable-Value": {
+      "type": "string",
+      "defaultValue": "https://www.nationalbanken.dk/"
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Logic/workflows",
+      "apiVersion": "2016-06-01",
+      "name": "[parameters('logicAppName')]",
+      "location": "[parameters('logicAppLocation')]",
+      "dependsOn": [],
+      "properties": {
+        "definition": {
+          "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+          "actions": {
+            "HTTP": {
+              "inputs": {
+                "method": "GET",
+                "uri": "[parameters('HTTP-URI')]"
+              },
+              "runAfter": {
+                "Initialize_variable": [
+                  "Succeeded"
+                ]
+              },
+              "type": "Http"
+            },
+            "Initialize-Array-NoValue": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestArrayNoValue",
+                    "type": "Array"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-Object-Value": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize-Array-Value": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestArrayValue",
+                    "type": "Array",
+                    "value": "[parameters('Initialize-Array-Value-Value')]"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-Array-NoValue": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize-Boolean-False": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestBoolFalseNormal",
+                    "type": "Boolean",
+                    "value": "[parameters('Initialize-Boolean-False-Value')]"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-Boolean-True-Expression": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize-Boolean-False-Expression": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestBoolFalseExpression",
+                    "type": "Boolean",
+                    "value": "[parameters('Initialize-Boolean-False-Expression-Value')]"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-Boolean-False": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize-Boolean-True": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestBoolTrueNormal",
+                    "type": "Boolean",
+                    "value": "[parameters('Initialize-Boolean-True-Value')]"
+                  }
+                ]
+              },
+              "runAfter": {},
+              "type": "InitializeVariable"
+            },
+            "Initialize-Boolean-True-Expression": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestBoolTrueExpression",
+                    "type": "Boolean",
+                    "value": "[parameters('Initialize-Boolean-True-Expression-Value')]"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-Boolean-True": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize-Float-0.01": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestFloatValue",
+                    "type": "Float",
+                    "value": "[parameters('Initialize-Float-0.01-Value')]"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-Float-NoValue": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize-Float-NoValue": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestFloatNoValue",
+                    "type": "Float"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-Integer-0": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize-Integer-0": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestIntegerValue",
+                    "type": "Integer",
+                    "value": "[parameters('Initialize-Integer-0-Value')]"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-Integer-NoValue": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize-Integer-NoValue": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestIntegerNoValue",
+                    "type": "Integer"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-String-Null-Expression": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize-Object-NoValue": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestObjectNoValue",
+                    "type": "Object"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-Float-0.01": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize-Object-Value": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestObjectValue",
+                    "type": "Object",
+                    "value": "[parameters('Initialize-Object-Value-Value')]"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-Object-NoValue": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize-String-NoValue": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestStringNoValue",
+                    "type": "String"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-Boolean-False-Expression": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize-String-Null-Code": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestStringNullFromCode",
+                    "type": "String",
+                    "value": "[parameters('Initialize-String-Null-Code-Value')]"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-String-NoValue": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize-String-Null-Expression": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "TestStringNullExpression",
+                    "type": "String",
+                    "value": "[parameters('Initialize-String-Null-Expression-Value')]"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-String-Null-Code": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            },
+            "Initialize_variable": {
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "URL",
+                    "type": "String",
+                    "value": "[parameters('Initialize_variable-Value')]"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize-Array-Value": [
+                  "Succeeded"
+                ]
+              },
+              "type": "InitializeVariable"
+            }
+          },
+          "contentVersion": "1.0.0.0",
+          "outputs": {},
+          "parameters": {},
+          "triggers": {
+            "manual": {
+              "inputs": {
+                "schema": {}
+              },
+              "kind": "Http",
+              "type": "Request"
+            }
+          }
+        },
+        "parameters": {}
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/LogicAppTemplate.Test/VariableUpdaterTests.cs
+++ b/LogicAppTemplate.Test/VariableUpdaterTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using Newtonsoft.Json.Linq;
+
+namespace LogicAppTemplate.Test
+{
+    [TestClass]
+    public class UpdateTemplateVariableTests
+    {
+        [TestMethod]
+        public void CreateUpdateTemplateVariableToValueClass()
+        {
+            new UpdateTemplateVariableReferenceToValue("","","");
+        }
+
+        [TestMethod]
+        public void GenerateParameterFileFromTemplate()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.VariableReference.json");
+            var generator = new UpdateTemplateVariableReferenceToValue("", "URL", "https://www.nationalbanken.dk/");
+
+            var definition = generator.UpdateTemplateVariable(content);
+            Assert.AreEqual(definition["parameters"]["HTTP-URI"]["defaultValue"], (JValue)"https://www.nationalbanken.dk/_vti_bin/DN/DataService.svc/CurrencyRatesXML?lang=da");
+        }
+
+        private static string GetEmbededFileContent(string resourceName)
+        {
+            var assembly = System.Reflection.Assembly.GetExecutingAssembly();
+
+
+            using (Stream stream = assembly.GetManifestResourceStream(resourceName))
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                return reader.ReadToEnd();
+            }
+
+        }
+
+    }
+}

--- a/LogicAppTemplate/LogicAppTemplate.csproj
+++ b/LogicAppTemplate/LogicAppTemplate.csproj
@@ -59,6 +59,7 @@
     <Compile Include="AzureResourceId.cs" />
     <Compile Include="Constants\Constants.cs" />
     <Compile Include="EmptyParameterTemplateGenerator.cs" />
+    <Compile Include="UpdateTemplateVariableToValueCmdlet.cs" />
     <Compile Include="GeneratorCustomConnectorCmdlet.cs" />
     <Compile Include="GeneratorIASchemaCmdlet.cs" />
     <Compile Include="GeneratorIAMapCmdlet.cs" />

--- a/LogicAppTemplate/UpdateTemplateVariableToValueCmdlet.cs
+++ b/LogicAppTemplate/UpdateTemplateVariableToValueCmdlet.cs
@@ -51,7 +51,11 @@ namespace LogicAppTemplate
         public JObject UpdateTemplateVariable(string logicAppTemplateJson)
         {
             string pattern = string.Format("@{{variables('{0}')}}", Variable);
-            return JObject.Parse(logicAppTemplateJson.Replace(pattern, Value));
+            string res = logicAppTemplateJson.Replace(pattern, Value);
+
+            pattern = string.Format("@variables('{0}')", Variable);
+            res = res.Replace(pattern, Value);
+            return JObject.Parse(res);
         }
 
         protected override void ProcessRecord()

--- a/LogicAppTemplate/UpdateTemplateVariableToValueCmdlet.cs
+++ b/LogicAppTemplate/UpdateTemplateVariableToValueCmdlet.cs
@@ -1,0 +1,64 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using LogicAppTemplate.Models;
+using Newtonsoft.Json;
+using System.Dynamic;
+using System.IO;
+
+namespace LogicAppTemplate
+{
+    [Cmdlet(VerbsData.Update, "TemplateVariableReferenceToValue", ConfirmImpact = ConfirmImpact.None)]
+    public class UpdateTemplateVariableReferenceToValue : PSCmdlet
+    {
+        [Parameter(
+            Mandatory = true,
+            HelpMessage = "The path to the template file"
+            )]
+        [Alias("Path")]
+        public string TemplateFile;
+
+        [Parameter(
+            Mandatory = true,
+            HelpMessage = "Name of the variable reference to switch out"
+            )]
+        [Alias("Name")]
+        public string Variable;
+        
+        [Parameter(
+            Mandatory = true,
+            HelpMessage = "Value that should be inserted instead of the current variable reference"
+            )]
+        public string Value;
+
+        public UpdateTemplateVariableReferenceToValue()
+        {
+
+        }
+
+        public UpdateTemplateVariableReferenceToValue(string TemplateFile, string Variable, string Value)
+        {
+            this.TemplateFile = TemplateFile;
+            this.Variable = Variable;
+            this.Value = Value;
+        }
+
+        public JObject UpdateTemplateVariable(string logicAppTemplateJson)
+        {
+            string pattern = string.Format("@{{variables('{0}')}}", Variable);
+            return JObject.Parse(logicAppTemplateJson.Replace(pattern, Value));
+        }
+
+        protected override void ProcessRecord()
+        {
+            string logicappTemplate = File.ReadAllText(TemplateFile);
+            JObject result = UpdateTemplateVariable(logicappTemplate);
+            WriteObject(result.ToString());
+        }
+    }
+}


### PR DESCRIPTION
New functions / cmdlet:

`Update-TemplateVariableReferenceToValue`
```
Synopsis:
Update or replace an variable reference to a value

Description:
Update or replace a variable reference to a value

It could be that you want to reference another variable

It could be that you want to put in a static value instead

It would be that you want to reference an ARM parameter value instead
```

The user story is that you might be doing some early Proof-of-Concept development and have a simple variable in your design that you use multiple times. When you want to bring the PoC into development, you might want to change the variable reference. That could another variable, a static value or an ARM template parameter, so you don't have to create more than one parameter, but can easily switch out the multiple variable references to a single ARM template parameter.

External help is a bit hard to write these days, while we are waiting for you to uptake the other PR's.