### PR TITLE
Implement managed identity support

### DIFF
--- a/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
+++ b/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
@@ -144,6 +144,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <EmbeddedResource Include="TestFiles\ManagedIdentity.json" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/LogicAppTemplate.Test/TemplateGeneratorTests.cs
+++ b/LogicAppTemplate.Test/TemplateGeneratorTests.cs
@@ -352,6 +352,45 @@ namespace LogicAppTemplate.Tests
             Assert.IsNull(defintion["parameters"]["Initialize-String-NoValue"]);
         }
 
+
+
+        [TestMethod()]
+        public void TestManagedIdentityNotSet()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.HTTP-basic.json");
+
+            var generator = new TemplateGenerator("", "", "", null);
+
+            var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
+
+            Assert.IsNull(defintion["resources"][0]["identity"]);
+        }
+        [TestMethod()]
+        public void TestManagedIdentityForced()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.HTTP-basic.json");
+
+            var generator = new TemplateGenerator("", "", "", null);
+            generator.ForceManagedIdentity = true;
+
+            var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
+
+            Assert.IsNotNull(defintion["resources"][0]["identity"]);
+        }
+
+
+        [TestMethod()]
+        public void TestManagedIdentityFromResource()
+        {
+            var content = GetEmbededFileContent("LogicAppTemplate.Test.TestFiles.ManagedIdentity.json");
+
+            var generator = new TemplateGenerator("", "", "", null);
+
+            var defintion = generator.generateDefinition(JObject.Parse(content)).GetAwaiter().GetResult();
+
+            Assert.IsNotNull(defintion["resources"][0]["identity"]);
+        }
+
         [TestMethod()]
         public void TestExtractVariablesSet()
         {

--- a/LogicAppTemplate.Test/TestFiles/ManagedIdentity.json
+++ b/LogicAppTemplate.Test/TestFiles/ManagedIdentity.json
@@ -1,0 +1,105 @@
+﻿{
+  "properties": {
+    "provisioningState": "Succeeded",
+    "createdTime": "2019-11-17T12:21:15.2623543Z",
+    "changedTime": "2019-11-17T12:21:53.7808555Z",
+    "state": "Enabled",
+    "version": "08586276135717263727",
+    "accessEndpoint": "https://prod-107.westeurope.logic.azure.com:443/workflows/aae9ac08076246f696c88aabf789918c",
+    "definition": {
+      "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {
+        "$connections": {
+          "defaultValue": {},
+          "type": "Object"
+        }
+      },
+      "triggers": {
+        "manual": {
+          "type": "Request",
+          "kind": "Http",
+          "inputs": {
+            "schema": {}
+          }
+        }
+      },
+      "actions": {
+        "Compose": {
+          "runAfter": {},
+          "type": "Compose",
+          "inputs": "Hey"
+        }
+      },
+      "outputs": {}
+    },
+    "parameters": {},
+    "endpointsConfiguration": {
+      "workflow": {
+        "outgoingIpAddresses": [
+          {
+            "address": "40.68.222.65"
+          },
+          {
+            "address": "40.68.209.23"
+          },
+          {
+            "address": "13.95.147.65"
+          },
+          {
+            "address": "23.97.218.130"
+          },
+          {
+            "address": "51.144.182.201"
+          },
+          {
+            "address": "23.97.211.179"
+          },
+          {
+            "address": "104.45.9.52"
+          },
+          {
+            "address": "23.97.210.126"
+          }
+        ],
+        "accessEndpointIpAddresses": [
+          {
+            "address": "13.95.155.53"
+          },
+          {
+            "address": "52.174.54.218"
+          },
+          {
+            "address": "52.174.49.6"
+          },
+          {
+            "address": "52.174.49.6"
+          }
+        ]
+      },
+      "connector": {
+        "outgoingIpAddresses": [
+          {
+            "address": "13.69.64.208/28"
+          },
+          {
+            "address": "40.115.50.13"
+          },
+          {
+            "address": "52.174.88.118"
+          }
+        ]
+      }
+    }
+  },
+  "id": "/subscriptions/b7a710a5-9da0-42a0-8684-b55ef154ddd6/resourceGroups/FO_Misc/providers/Microsoft.Logic/workflows/Test-Identity",
+  "name": "Test-Identity",
+  "type": "Microsoft.Logic/workflows",
+  "location": "westeurope",
+  "tags": {},
+  "identity": {
+    "type": "SystemAssigned",
+    "principalId": "51b67b9f-9693-4dcd-a858-f08dacd9b572",
+    "tenantId": "e674da86-7ee5-40a7-b777-7f835c89f4e1"
+  }
+}

--- a/LogicAppTemplate/GeneratorCmdlet.cs
+++ b/LogicAppTemplate/GeneratorCmdlet.cs
@@ -51,6 +51,9 @@ namespace LogicAppTemplate
         [Parameter(Mandatory = false, HelpMessage = "If supplied, the LA ARM Template will be set to Disabled and won't be automatically run when deployed")]
         public SwitchParameter DisabledState;
 
+        [Parameter(Mandatory = false, HelpMessage = "If supplied, Managed Identity for the Logic App will be set in the ARM template")]
+        public SwitchParameter ForceManagedIdentity;
+
         protected override void ProcessRecord()
         {
             AzureResourceCollector resourceCollector = new AzureResourceCollector();
@@ -83,7 +86,8 @@ namespace LogicAppTemplate
             {
                 DiagnosticSettings = this.DiagnosticSettings,
                 GenerateHttpTriggerUrlOutput = this.GenerateHttpTriggerUrlOutput,
-                IncludeInitializeVariable = this.IncludeInitializeVariable
+                IncludeInitializeVariable = this.IncludeInitializeVariable,
+                ForceManagedIdentity = this.ForceManagedIdentity
             };
             
             try

--- a/LogicAppTemplate/TemplateGenerator.cs
+++ b/LogicAppTemplate/TemplateGenerator.cs
@@ -126,8 +126,13 @@ namespace LogicAppTemplate
                 }
             }
 
+            var managedIdentity = (JObject)definition["identity"];
 
-
+            if(managedIdentity != null && managedIdentity.Value<string>("type") == "SystemAssigned")
+            {
+                template.resources[0].Add("identity", JObject.Parse("{'type': 'SystemAssigned'}"));
+            }
+            
             // WriteVerbose("Checking connections...");
             if (connections == null)
                 return JObject.FromObject(template);

--- a/LogicAppTemplate/TemplateGenerator.cs
+++ b/LogicAppTemplate/TemplateGenerator.cs
@@ -51,6 +51,7 @@ namespace LogicAppTemplate
         public bool IncludeInitializeVariable { get; set; }
         public bool FixedFunctionAppName { get; set; }
         public bool GenerateHttpTriggerUrlOutput { get; set; }
+        public bool ForceManagedIdentity { get; set; }
 
         public async Task<JObject> GenerateTemplate()
         {
@@ -162,7 +163,7 @@ namespace LogicAppTemplate
 
             var managedIdentity = (JObject)definition["identity"];
 
-            if(managedIdentity != null && managedIdentity.Value<string>("type") == "SystemAssigned")
+            if(ForceManagedIdentity || (managedIdentity != null && managedIdentity.Value<string>("type") == "SystemAssigned"))
             {
                 template.resources[0].Add("identity", JObject.Parse("{'type': 'SystemAssigned'}"));
             }


### PR DESCRIPTION
I believe that we should support that when a Logic App has Managed Identity set, our export of the definition / template should reflect that as well.

Adding support for a ForceManagedIdentity paramter was easy, so I included that as well.

I hope you'll find the feature valuable and I hope you will uptake it.