### PR TITLE
Bump Newtonsoft.Json from 13.0.2 to 13.0.3

### DIFF
--- a/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
+++ b/LogicAppTemplate.Test/LogicAppTemplate.Test.csproj
@@ -38,7 +38,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />

--- a/LogicAppTemplate.Test/packages.config
+++ b/LogicAppTemplate.Test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
 </packages>

--- a/LogicAppTemplate/LogicAppTemplate.csproj
+++ b/LogicAppTemplate/LogicAppTemplate.csproj
@@ -35,7 +35,7 @@
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.5.3.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/LogicAppTemplate/packages.config
+++ b/LogicAppTemplate/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="5.3.0" targetFramework="net48" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.1" targetFramework="net48" />
   <package id="Microsoft.NETCore.Targets" version="1.1.3" targetFramework="net48" />
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
   <package id="System.IO" version="4.3.0" targetFramework="net48" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />
   <package id="System.Private.Uri" version="4.3.2" targetFramework="net48" />


### PR DESCRIPTION
Bumps Newtonsoft.Json from 13.0.2 to 13.0.3

### Release notes
- Fix - Fixed parsed zero decimals losing trailing zeroes
- Fix - Fixed parsed negative zero double losing negative
- Fix - Fixed null string being reported as String rather than JTokenType.Null