### PR TITLE
Refactor parameter handling for managed identities

### DIFF
--- a/LogicAppTemplate/TemplateGenerator.cs
+++ b/LogicAppTemplate/TemplateGenerator.cs
@@ -232,7 +232,7 @@ namespace LogicAppTemplate
                 var identity = new AzureResourceId(identities[0].Name);
 
                 //Add ARM parameter to configure the user assigned identity
-                template.parameters.Add(Constants.UserAssignedIdentityParameterName, JObject.FromObject(new { type = "string", defaultValue = identity.ResourceName }));
+                AddTemplateParameter(Constants.UserAssignedIdentityParameterName, "string", identity.ResourceName);
 
                 //When the identity exists in a different resourcegroup add this as parameter and in the resourceId() function
                 var identityResourceGroupAddtion = "";
@@ -669,7 +669,7 @@ namespace LogicAppTemplate
                                 }
 
                                 //User Assigned Identity
-                                definition["actions"][action.Name]["inputs"]["authentication"]["identity"] = $"[resourceId({identityResourceGroupAddtion}'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('{Constants.UserAssignedIdentityParameterName}'))]";
+                                definition["actions"][action.Name]["inputs"]["authentication"]["identity"] = $"[resourceId({identityResourceGroupAddtion}'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('{AddTemplateParameter(Constants.UserAssignedIdentityParameterName, "string", identityResource.ResourceName)}'))]";
                             }
                         }
 


### PR DESCRIPTION
Refactored `TemplateGenerator.cs` to use the `AddTemplateParameter` helper method for adding user-assigned managed identity parameters. This replaces direct additions to `template.parameters`, improving code readability, reusability, and consistency. Updated the construction of `resourceId` strings to leverage the centralized parameter addition logic. Removed outdated commented code for resource group parameter handling.